### PR TITLE
feat: add task management APIs, bidirectional BFS, test suite overhau…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ It uses Redis to store the BFS state instead of holding everything in memory, wh
 - Async task processing — searches run in the background, results polled live
 - Real-time progress updates during search
 - Interactive D3.js graph visualization of the path
-- Explore page connections for arbitrary graph visualization
 - Persistent search state — page refreshes resume from where you left off
 
 ## Tech Stack
@@ -64,7 +63,6 @@ Swagger docs at [http://localhost:9020/api/docs](http://localhost:9020/api/docs)
 |--------|----------|-------------|
 | `POST` | `/getPath` | Start a pathfinding task, returns `task_id` |
 | `GET` | `/tasks/status/<id>` | Poll task status and live progress |
-| `POST` | `/explore` | Get outgoing links from a page for graph viz |
 | `GET` | `/health` | Redis + cache + Wikipedia API health check |
 | `GET` | `/api/docs` | Swagger UI |
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -2,18 +2,15 @@ import os
 
 from flask import Blueprint, jsonify, redirect, request, send_from_directory, url_for
 
+from app import celery
 from app.api.middleware import api_endpoint
 from app.api.schemas import (
-    ExploreRequestSchema,
-    ExploreResultSchema,
     SearchRequestSchema,
-    serialize_response,
     validate_request_data,
 )
 from app.core.factory import (
     ServiceFactory,
     get_cache_management_service,
-    get_explore_service,
 )
 from app.infrastructure.tasks import find_path_task
 from app.utils.logging import get_logger
@@ -189,52 +186,6 @@ def get_task_status_route(task_id):
     return jsonify(response_data)
 
 
-@main.route("/explore", methods=["POST"])
-@api_endpoint()
-def explore_route():
-    """Fetch outgoing links from a Wikipedia page for graph visualization.
-    ---
-    tags:
-      - Exploration
-    summary: Explore page connections
-    parameters:
-      - in: body
-        name: body
-        required: true
-        schema:
-          type: object
-          required:
-            - start_page
-          properties:
-            start_page:
-              type: string
-              example: "Python (programming language)"
-            max_links:
-              type: integer
-              default: 10
-              description: Maximum number of links to return
-    responses:
-      200:
-        description: Page connections for visualization
-      400:
-        description: Validation error
-      404:
-        description: Page not found
-    """
-    explore_request = validate_request_data(ExploreRequestSchema, request.get_json())
-
-    logger.info(
-        f"Explore request: {explore_request.start_page} (max_links: {explore_request.max_links})"
-    )
-
-    explore_service = get_explore_service()
-    result = explore_service.explore_page(explore_request)
-
-    response_data = serialize_response(ExploreResultSchema, result)
-
-    return jsonify(response_data), 200
-
-
 @main.route("/health", methods=["GET"])
 @api_endpoint(require_json_content=False, log_request=False)
 def health_check():
@@ -336,6 +287,177 @@ def clear_cache():
         raise
 
 
+@main.route("/tasks", methods=["GET"])
+@api_endpoint(require_json_content=False)
+def list_tasks():
+    """List all active, reserved, and scheduled Celery tasks across all workers.
+    ---
+    tags:
+      - Tasks
+    summary: List tasks
+    responses:
+      200:
+        description: Current task queues across all workers
+        schema:
+          type: object
+          properties:
+            active:
+              type: object
+              description: Tasks currently being executed, keyed by worker name
+            reserved:
+              type: object
+              description: Tasks claimed by workers but not yet executing
+            scheduled:
+              type: object
+              description: Tasks scheduled for future execution (ETA/countdown)
+            total_active:
+              type: integer
+            total_reserved:
+              type: integer
+      503:
+        description: Could not reach Celery workers
+    """
+    try:
+        inspect = celery.control.inspect(timeout=2.0)
+        active = inspect.active() or {}
+        reserved = inspect.reserved() or {}
+        scheduled = inspect.scheduled() or {}
+
+        total_active = sum(len(tasks) for tasks in active.values())
+        total_reserved = sum(len(tasks) for tasks in reserved.values())
+
+        return jsonify(
+            {
+                "active": active,
+                "reserved": reserved,
+                "scheduled": scheduled,
+                "total_active": total_active,
+                "total_reserved": total_reserved,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Failed to inspect Celery workers: {e}")
+        return jsonify(
+            {"error": "Could not reach Celery workers", "detail": str(e)}
+        ), 503
+
+
+@main.route("/tasks/<task_id>", methods=["DELETE"])
+@api_endpoint(require_json_content=False)
+def cancel_task(task_id):
+    """Revoke a task, preventing it from running or terminating it if already running.
+    ---
+    tags:
+      - Tasks
+    summary: Cancel task
+    parameters:
+      - name: task_id
+        in: path
+        required: true
+        type: string
+        description: Celery task ID to cancel
+      - name: terminate
+        in: query
+        type: boolean
+        default: true
+        description: Send SIGTERM to the worker process if the task is already running
+    responses:
+      200:
+        description: Task revoked
+        schema:
+          type: object
+          properties:
+            revoked:
+              type: boolean
+            task_id:
+              type: string
+            terminated:
+              type: boolean
+      404:
+        description: Task not found or already completed
+    """
+    terminate = request.args.get("terminate", "true").lower() != "false"
+
+    # Check current state before revoking
+    task = find_path_task.AsyncResult(task_id)  # type: ignore[attr-defined]
+    if task.state in ("SUCCESS", "FAILURE"):
+        return jsonify(
+            {
+                "revoked": False,
+                "task_id": task_id,
+                "reason": f"Task already in terminal state: {task.state}",
+            }
+        ), 404
+
+    celery.control.revoke(task_id, terminate=terminate, signal="SIGTERM")
+    logger.info(f"Revoked task {task_id} (terminate={terminate})")
+
+    return jsonify({"revoked": True, "task_id": task_id, "terminated": terminate})
+
+
+@main.route("/tasks", methods=["DELETE"])
+@api_endpoint(require_json_content=False)
+def cancel_all_tasks():
+    """Revoke all active and reserved tasks across all workers.
+    ---
+    tags:
+      - Tasks
+    summary: Cancel all tasks
+    parameters:
+      - name: terminate
+        in: query
+        type: boolean
+        default: true
+        description: Send SIGTERM to worker processes for tasks already running
+    responses:
+      200:
+        description: All tasks revoked
+        schema:
+          type: object
+          properties:
+            revoked_count:
+              type: integer
+            task_ids:
+              type: array
+              items:
+                type: string
+            terminated:
+              type: boolean
+      503:
+        description: Could not reach Celery workers
+    """
+    terminate = request.args.get("terminate", "true").lower() != "false"
+
+    try:
+        inspect = celery.control.inspect(timeout=2.0)
+        active = inspect.active() or {}
+        reserved = inspect.reserved() or {}
+
+        task_ids = []
+        for tasks in active.values():
+            task_ids.extend(t["id"] for t in tasks)
+        for tasks in reserved.values():
+            task_ids.extend(t["id"] for t in tasks)
+
+        for task_id in task_ids:
+            celery.control.revoke(task_id, terminate=terminate, signal="SIGTERM")
+
+        logger.info(f"Revoked {len(task_ids)} tasks (terminate={terminate})")
+
+        return jsonify(
+            {
+                "revoked_count": len(task_ids),
+                "task_ids": task_ids,
+                "terminated": terminate,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Failed to cancel all tasks: {e}")
+        return jsonify(
+            {"error": "Could not reach Celery workers", "detail": str(e)}
+        ), 503
+
+
 @main.route("/")
 @api_endpoint(require_json_content=False, log_request=False)
 def index():
@@ -383,7 +505,9 @@ def api_info():
         "endpoints": {
             "POST /getPath": "Start pathfinding between two pages",
             "GET /tasks/status/<task_id>": "Check task status",
-            "POST /explore": "Explore page connections",
+            "GET /tasks": "List active/reserved/scheduled tasks",
+            "DELETE /tasks/<task_id>": "Cancel a specific task",
+            "DELETE /tasks": "Cancel all active tasks",
             "GET /health": "Health check",
             "GET /": "Path visualization UI",
             "GET /api": "API information",
@@ -397,7 +521,7 @@ def api_info():
 @main.route("/<path:path>")
 def catch_all(path):
     """Redirect all non-API paths to main UI."""
-    api_paths = ["getPath", "tasks", "explore", "health", "cache", "api"]
+    api_paths = ["getPath", "tasks", "health", "cache", "api"]
 
     if any(path.startswith(api_path) for api_path in api_paths):
         response_data = {
@@ -408,42 +532,3 @@ def catch_all(path):
         return jsonify(response_data), 404
 
     return redirect(url_for("main.index"))
-
-
-@main.errorhandler(404)
-def not_found(error):
-    """Handle 404 errors."""
-    return jsonify(
-        {"error": True, "message": "Endpoint not found", "code": "NOT_FOUND"}
-    ), 404
-
-
-@main.errorhandler(405)
-def method_not_allowed(error):
-    """Handle 405 errors."""
-    return (
-        jsonify(
-            {
-                "error": True,
-                "message": "Method not allowed",
-                "code": "METHOD_NOT_ALLOWED",
-            }
-        ),
-        405,
-    )
-
-
-@main.errorhandler(500)
-def internal_error(error):
-    """Handle 500 errors."""
-    logger.error(f"Internal server error: {error}")
-    return (
-        jsonify(
-            {
-                "error": True,
-                "message": "Internal server error",
-                "code": "INTERNAL_ERROR",
-            }
-        ),
-        500,
-    )

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from marshmallow import Schema, fields, post_load, validate
 
-from app.core.models import ExploreRequest, SearchRequest
+from app.core.models import SearchRequest
 
 
 class SearchRequestSchema(Schema):
@@ -38,72 +38,12 @@ class SearchRequestSchema(Schema):
         )
 
 
-class ExploreRequestSchema(Schema):
-    """Schema for page exploration requests."""
-
-    start = fields.Str(
-        required=True,
-        validate=validate.Length(min=1, max=255),
-        error_messages={"required": "Start page is required"},
-    )
-    max_links = fields.Int(load_default=10, validate=validate.Range(min=1, max=50))
-
-    @post_load
-    def make_request(self, data, **kwargs):
-        """Convert validated data to ExploreRequest object."""
-        return ExploreRequest(
-            start_page=data["start"].strip(), max_links=data.get("max_links", 10)
-        )
-
-
-class PathResultSchema(Schema):
-    """Schema for pathfinding results."""
-
-    path = fields.List(fields.Str(), required=True)
-    length = fields.Int(required=True)
-    start_page = fields.Str(required=True)
-    end_page = fields.Str(required=True)
-    search_time = fields.Float(allow_none=True)
-    nodes_explored = fields.Int(allow_none=True)
-
-
-class ExploreResultSchema(Schema):
-    """Schema for exploration results."""
-
-    start_page = fields.Str(required=True)
-    nodes = fields.List(fields.Str(), required=True)
-    edges = fields.List(fields.Tuple((fields.Str(), fields.Str())), required=True)
-    total_links = fields.Int(required=True)
-
-
-class TaskStatusSchema(Schema):
-    """Schema for task status responses."""
-
-    status = fields.Str(required=True)
-    task_id = fields.Str(required=True)
-    result = fields.Dict(allow_none=True)
-    error = fields.Str(allow_none=True)
-    progress = fields.Dict(allow_none=True)
-    poll_url = fields.Str(allow_none=True)
-
-
 class ErrorResponseSchema(Schema):
     """Schema for error responses."""
 
     error = fields.Bool(required=True, dump_default=True)
     message = fields.Str(required=True)
     code = fields.Str(allow_none=True)
-    details = fields.Dict(allow_none=True)
-
-
-class HealthCheckSchema(Schema):
-    """Schema for health check responses."""
-
-    status = fields.Str(required=True)
-    redis_status = fields.Str(required=True)
-    celery_status = fields.Str(required=True)
-    wikipedia_api_status = fields.Str(required=True)
-    timestamp = fields.Str(required=True)
     details = fields.Dict(allow_none=True)
 
 
@@ -123,18 +63,3 @@ def validate_request_data(schema_class: type[Schema], data: Any) -> Any:
     """
     schema = schema_class()
     return schema.load(data)  # Let the original ValidationError bubble up
-
-
-def serialize_response(schema_class: type[Schema], data: Any) -> Any:
-    """
-    Serialize response data using the specified schema.
-
-    Args:
-        schema_class: Marshmallow schema class
-        data: Data to serialize
-
-    Returns:
-        Serialized data
-    """
-    schema = schema_class()
-    return schema.dump(data)

--- a/app/api/swagger.py
+++ b/app/api/swagger.py
@@ -13,12 +13,10 @@ SWAGGER_TEMPLATE = {
         "license": {"name": "MIT"},
     },
     "basePath": "/",
-
     "consumes": ["application/json"],
     "produces": ["application/json"],
     "tags": [
         {"name": "Pathfinding", "description": "Find paths between Wikipedia pages"},
-        {"name": "Exploration", "description": "Explore page connections"},
         {"name": "System", "description": "Health and administration"},
     ],
 }

--- a/app/core/factory.py
+++ b/app/core/factory.py
@@ -5,7 +5,6 @@ from flask import current_app
 from app.core.pathfinding import BidirectionalBFSPathFinder, RedisBasedBFSPathFinder
 from app.core.services import (
     CacheManagementService,
-    ExploreService,
     PathFindingService,
     WikipediaService,
 )
@@ -61,11 +60,19 @@ class ServiceFactory:
             max_workers = current_app.config.get("WIKIPEDIA_MAX_WORKERS", 10)
             cache_ttl = current_app.config.get("CACHE_TTL", 86400)
             api_timeout = current_app.config.get("WIKIPEDIA_API_TIMEOUT", 15)
+            max_paginate_calls = current_app.config.get(
+                "WIKIPEDIA_MAX_PAGINATE_CALLS", 3
+            )
+            request_delay = current_app.config.get("WIKIPEDIA_REQUEST_DELAY", 0.1)
+            max_retries = current_app.config.get("WIKIPEDIA_BACKOFF_MAX_RETRIES", 5)
             cls._wikipedia_client = WikipediaClient(
                 cache_service=cache_service,
                 max_workers=max_workers,
                 cache_ttl=cache_ttl,
                 api_timeout=api_timeout,
+                max_paginate_calls=max_paginate_calls,
+                request_delay=request_delay,
+                max_retries=max_retries,
             )
             logger.info("Wikipedia client created with caching enabled")
         return cls._wikipedia_client
@@ -105,14 +112,6 @@ class ServiceFactory:
         return PathFindingService(path_finder, cache_service, wikipedia_client)
 
     @classmethod
-    def create_explore_service(cls) -> ExploreService:
-        """Create explore service."""
-        wikipedia_client = cls.get_wikipedia_client()
-        cache_service = cls.get_cache_service()
-
-        return ExploreService(wikipedia_client, cache_service)
-
-    @classmethod
     def create_wikipedia_service(cls) -> WikipediaService:
         """Create Wikipedia service."""
         wikipedia_client = cls.get_wikipedia_client()
@@ -147,11 +146,6 @@ def get_pathfinding_service(
 ) -> PathFindingService:
     """Convenience function to get pathfinding service."""
     return ServiceFactory.create_pathfinding_service(algorithm, progress_callback)
-
-
-def get_explore_service() -> ExploreService:
-    """Convenience function to get explore service."""
-    return ServiceFactory.create_explore_service()
 
 
 def get_wikipedia_service() -> WikipediaService:

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -35,38 +35,6 @@ class PathResult:
 
 
 @dataclass
-class ExploreResult:
-    """Result of an explore operation."""
-
-    start_page: str
-    nodes: list[str]
-    edges: list[tuple]
-    total_links: int
-
-    @property
-    def is_valid(self) -> bool:
-        """Check if the explore result is valid."""
-        return (
-            self.start_page in self.nodes
-            and len(self.nodes) > 0
-            and self.total_links >= 0
-        )
-
-
-@dataclass
-class TaskInfo:
-    """Information about a background task."""
-
-    task_id: str
-    status: TaskStatus
-    result: dict | None = None
-    error: str | None = None
-    progress: dict | None = None
-    created_at: str | None = None
-    updated_at: str | None = None
-
-
-@dataclass
 class SearchRequest:
     """Request for pathfinding search."""
 
@@ -82,18 +50,6 @@ class SearchRequest:
             and bool(self.end_page and self.end_page.strip())
             and self.start_page != self.end_page
         )
-
-
-@dataclass
-class ExploreRequest:
-    """Request for page exploration."""
-
-    start_page: str
-    max_links: int | None = None
-
-    def validate(self) -> bool:
-        """Validate the explore request."""
-        return bool(self.start_page and self.start_page.strip())
 
 
 @dataclass

--- a/app/core/pathfinding.py
+++ b/app/core/pathfinding.py
@@ -65,13 +65,6 @@ class RedisBasedBFSPathFinder(PathFinderInterface):
         if start_page == end_page:
             return {"path": [start_page], "nodes_explored": 1}
 
-        # Check if pages exist
-        if not self.wikipedia_client.page_exists(start_page):
-            raise InvalidPageError(f"Start page '{start_page}' does not exist")
-
-        if not self.wikipedia_client.page_exists(end_page):
-            raise InvalidPageError(f"End page '{end_page}' does not exist")
-
         # Generate unique session ID for this search
         session_id = str(uuid.uuid4())
         queue_key = f"bfs_queue:{session_id}"
@@ -296,10 +289,9 @@ class BidirProgressAggregator:
                 self._fwd_nodes += 1
             else:
                 self._bwd_nodes += 1
-            combined_queue = (
-                self._queue_service.length(self._fwd_q)
-                + self._queue_service.length(self._bwd_q)
-            )
+            combined_queue = self._queue_service.length(
+                self._fwd_q
+            ) + self._queue_service.length(self._bwd_q)
             self._callback(
                 {
                     "nodes_explored": self._fwd_nodes + self._bwd_nodes,
@@ -356,12 +348,6 @@ class BidirectionalBFSPathFinder(PathFinderInterface):
         if start_page == end_page:
             return {"path": [start_page], "nodes_explored": 1}
 
-        if not self.wikipedia_client.page_exists(start_page):
-            raise InvalidPageError(f"Start page '{start_page}' does not exist")
-
-        if not self.wikipedia_client.page_exists(end_page):
-            raise InvalidPageError(f"End page '{end_page}' does not exist")
-
         sid = str(uuid.uuid4())[:8]
 
         fwd_q = f"bfs_fwd_queue:{sid}"
@@ -403,7 +389,10 @@ class BidirectionalBFSPathFinder(PathFinderInterface):
                 bwd_max,
                 tracker,
             )
-            return {"path": path, "nodes_explored": tracker.total_nodes if tracker else 0}
+            return {
+                "path": path,
+                "nodes_explored": tracker.total_nodes if tracker else 0,
+            }
         finally:
             self.cache_service.delete_many(keys)
 
@@ -430,11 +419,25 @@ class BidirectionalBFSPathFinder(PathFinderInterface):
 
             if bwd_size > 0 and (fwd_size == 0 or bwd_size < fwd_size):
                 meeting = self._expand_backward_batch(
-                    end_page, bwd_q, bwd_vis, bwd_par, fwd_vis, fwd_par, bwd_max, tracker
+                    end_page,
+                    bwd_q,
+                    bwd_vis,
+                    bwd_par,
+                    fwd_vis,
+                    fwd_par,
+                    bwd_max,
+                    tracker,
                 )
             else:
                 meeting = self._expand_forward_batch(
-                    start_page, fwd_q, fwd_vis, fwd_par, bwd_vis, bwd_par, fwd_max, tracker
+                    start_page,
+                    fwd_q,
+                    fwd_vis,
+                    fwd_par,
+                    bwd_vis,
+                    bwd_par,
+                    fwd_max,
+                    tracker,
                 )
 
             if meeting is not None:

--- a/app/core/services.py
+++ b/app/core/services.py
@@ -1,6 +1,6 @@
 import time
 
-import networkx as nx
+from flask import current_app
 
 from app.core.interfaces import (
     CacheServiceInterface,
@@ -8,8 +8,6 @@ from app.core.interfaces import (
     WikipediaClientInterface,
 )
 from app.core.models import (
-    ExploreRequest,
-    ExploreResult,
     PathResult,
     SearchRequest,
     WikipediaPage,
@@ -84,8 +82,10 @@ class PathFindingService:
 
             # Cache the result
             self.cache_service.set(
-                cache_key, result.__dict__, ttl=3600
-            )  # Cache for 1 hour
+                cache_key,
+                result.__dict__,
+                ttl=current_app.config.get("CACHE_PATH_TTL", 3600),
+            )
 
             logger.info(
                 f"Path found: {request.start_page} -> {request.end_page} (length: {len(path)}, time: {search_time:.2f}s)"
@@ -157,102 +157,6 @@ class PathFindingService:
         return start_exists, end_exists, validation_details
 
 
-class ExploreService:
-    """Service for exploring Wikipedia page connections."""
-
-    def __init__(
-        self,
-        wikipedia_client: WikipediaClientInterface,
-        cache_service: CacheServiceInterface,
-    ):
-        self.wikipedia_client = wikipedia_client
-        self.cache_service = cache_service
-
-    def explore_page(self, request: ExploreRequest) -> ExploreResult:
-        """
-        Explore connections from a Wikipedia page.
-
-        Args:
-            request: Explore request with start page and options
-
-        Returns:
-            ExploreResult with nodes and edges for visualization
-
-        Raises:
-            InvalidPageError: When request is invalid or page doesn't exist
-        """
-        if not request.validate():
-            raise InvalidPageError("Invalid explore request")
-
-        # Check cache first
-        cache_key = f"explore:{request.start_page}:{request.max_links}"
-        cached_result = self.cache_service.get(cache_key)
-        if cached_result:
-            logger.info(f"Explore result found in cache: {request.start_page}")
-            return ExploreResult(**cached_result)
-
-        # Check if page exists
-        if not self.wikipedia_client.page_exists(request.start_page):
-            raise InvalidPageError(f"Page '{request.start_page}' does not exist")
-
-        # Get links for the page
-        try:
-            links_data = self.wikipedia_client.get_links_bulk([request.start_page])
-            all_links = links_data.get(request.start_page, [])
-
-            if not all_links:
-                logger.warning(f"No links found for page: {request.start_page}")
-                return ExploreResult(
-                    start_page=request.start_page,
-                    nodes=[request.start_page],
-                    edges=[],
-                    total_links=0,
-                )
-
-            # Limit links for visualization
-            limited_links = all_links[: request.max_links]
-
-            # Generate graph data
-            result = self._generate_explore_graph(
-                request.start_page, limited_links, len(all_links)
-            )
-
-            # Cache the result
-            self.cache_service.set(
-                cache_key, result.__dict__, ttl=1800
-            )  # Cache for 30 minutes
-
-            logger.info(
-                f"Explore completed: {request.start_page} ({len(limited_links)} links shown)"
-            )
-            return result
-
-        except Exception as e:
-            logger.error(f"Explore failed for {request.start_page}: {e}")
-            raise
-
-    def _generate_explore_graph(
-        self, start_page: str, links: list[str], total_links: int
-    ) -> ExploreResult:
-        """Generate graph data for visualization."""
-        # Create graph
-        G = nx.Graph()
-        G.add_node(start_page)
-
-        nodes = [start_page]
-        edges = []
-
-        for link in links:
-            G.add_node(link)
-            G.add_edge(start_page, link)
-            nodes.append(link)
-            edges.append((start_page, link))
-
-        return ExploreResult(
-            start_page=start_page, nodes=nodes, edges=edges, total_links=total_links
-        )
-
-
 class WikipediaService:
     """Service for Wikipedia page operations."""
 
@@ -287,15 +191,13 @@ class WikipediaService:
         )
 
         # Cache the result
-        self.cache_service.set(cache_key, page.__dict__, ttl=7200)  # Cache for 2 hours
+        self.cache_service.set(
+            cache_key,
+            page.__dict__,
+            ttl=current_app.config.get("CACHE_PAGE_TTL", 7200),
+        )
 
         return page
-
-    def search_pages(self, query: str, limit: int = 10) -> list[str]:
-        """Search for Wikipedia pages by title."""
-        # This would implement Wikipedia search API
-        # For now, return empty list as it's not in the original scope
-        return []
 
 
 class CacheManagementService:

--- a/app/external/wikipedia.py
+++ b/app/external/wikipedia.py
@@ -1,9 +1,10 @@
+import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
 
 import requests
-from flask import current_app
 
 from app.core.interfaces import CacheServiceInterface, WikipediaClientInterface
 from app.utils.exceptions import WikipediaAPIError
@@ -22,20 +23,108 @@ class WikipediaClient(WikipediaClientInterface):
         max_workers: int = 10,
         cache_ttl: int = 86400,  # 24 hours
         api_timeout: int = 15,
+        max_paginate_calls: int = 3,
+        request_delay: float = 0.1,
+        max_retries: int = 5,
     ):
         self.session = session or requests.Session()
         self.cache_service = cache_service
         self.max_workers = max_workers
         self.cache_ttl = cache_ttl
         self.api_timeout = api_timeout
+        self.max_paginate_calls = max_paginate_calls
+        self.request_delay = request_delay
+        self.max_retries = max_retries
         self.base_url = "https://en.wikipedia.org/w/api.php"
+
+        # Shared rate limiter — enforces minimum interval between all requests
+        # across every thread that shares this client instance.
+        self._rate_lock = threading.Lock()
+        self._last_request_time: float = 0.0
 
         # Configure session
         self.session.headers.update(
             {
-                "User-Agent": "Iris-Wikipedia-Pathfinder/1.0 (https://github.com/example/iris)"
+                "User-Agent": "Iris-Wikipedia-Pathfinder/1.0 (https://github.com/mdhishaamakhtar/iris-web-backend)"
             }
         )
+
+    def _acquire_rate_slot(self) -> None:
+        """Block until the global rate limit allows the next request.
+
+        Uses a single lock shared across all threads so that concurrent workers
+        cannot burst past the configured ``request_delay`` interval.  The lock
+        is held *during* any sleep so that a second thread cannot race in and
+        start its own request before the interval has elapsed.
+        """
+        if self.request_delay <= 0:
+            return
+        with self._rate_lock:
+            now = time.monotonic()
+            wait = self.request_delay - (now - self._last_request_time)
+            if wait > 0:
+                time.sleep(wait)
+            self._last_request_time = time.monotonic()
+
+    def _request_with_backoff(self, params: dict[str, str | int]) -> requests.Response:
+        """GET the Wikipedia API with exponential backoff on 429 and 5xx responses.
+
+        Retries up to ``self.max_retries`` times.  On a 429 the ``Retry-After``
+        header is respected when present; otherwise the backoff is ``2^attempt``
+        seconds.  Network-level errors (``RequestException``) are also retried.
+        Other 4xx errors are raised immediately as ``WikipediaAPIError``.
+        """
+        for attempt in range(self.max_retries):
+            self._acquire_rate_slot()
+            try:
+                response = self.session.get(
+                    self.base_url, params=params, timeout=self.api_timeout
+                )
+            except requests.RequestException as e:
+                if attempt == self.max_retries - 1:
+                    raise WikipediaAPIError(f"API request failed: {e}")
+                wait = 2**attempt
+                logger.warning(
+                    f"Request error (attempt {attempt + 1}/{self.max_retries}), "
+                    f"retrying in {wait}s: {e}"
+                )
+                time.sleep(wait)
+                continue
+
+            if response.status_code == 429:
+                if attempt == self.max_retries - 1:
+                    raise WikipediaAPIError(
+                        f"Rate limited after {self.max_retries} retries"
+                    )
+                wait = int(response.headers.get("Retry-After", 2 ** (attempt + 1)))
+                logger.warning(
+                    f"Rate limited (429), retrying in {wait}s "
+                    f"(attempt {attempt + 1}/{self.max_retries})"
+                )
+                time.sleep(wait)
+                continue
+
+            if response.status_code >= 500:
+                if attempt == self.max_retries - 1:
+                    raise WikipediaAPIError(
+                        f"Server error {response.status_code} after {self.max_retries} retries"
+                    )
+                wait = 2**attempt
+                logger.warning(
+                    f"Server error {response.status_code} "
+                    f"(attempt {attempt + 1}/{self.max_retries}), retrying in {wait}s"
+                )
+                time.sleep(wait)
+                continue
+
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as e:
+                raise WikipediaAPIError(f"API error: {e}")
+
+            return response
+
+        raise WikipediaAPIError(f"API request failed after {self.max_retries} attempts")
 
     def _bulk_fetch(
         self,
@@ -86,12 +175,7 @@ class WikipediaClient(WikipediaClientInterface):
         if uncached_titles:
             fresh_results: dict[str, list[str]] = {}
 
-            # Read pagination config here (app context available), bind to fetch_fn
-            # so threads don't need to access current_app themselves.
-            max_paginate_calls = current_app.config.get(
-                "WIKIPEDIA_MAX_PAGINATE_CALLS", 10
-            )
-            bound_fetch = partial(fetch_fn, max_paginate_calls=max_paginate_calls)
+            bound_fetch = partial(fetch_fn, max_paginate_calls=self.max_paginate_calls)
 
             with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
                 future_to_title = {
@@ -183,24 +267,16 @@ class WikipediaClient(WikipediaClientInterface):
         max_pages = max_paginate_calls
         calls = 0
 
-        try:
-            while calls < max_pages:
-                response = self.session.get(
-                    self.base_url, params=params, timeout=self.api_timeout
-                )
-                response.raise_for_status()
-                data = response.json()
-                query_data = data.get("query", {})
-                page_links = self._parse_batch_response(query_data, [title])
-                all_links.extend(page_links.get(title, []))
-                calls += 1
-                if "continue" not in data:
-                    break
-                params["plcontinue"] = data["continue"]["plcontinue"]
-                params["continue"] = data["continue"]["continue"]
-        except requests.RequestException as e:
-            logger.error(f"Wikipedia API request failed for '{title}': {e}")
-            raise WikipediaAPIError(f"API request failed: {e}")
+        while calls < max_pages:
+            data = self._request_with_backoff(params).json()
+            query_data = data.get("query", {})
+            page_links = self._parse_batch_response(query_data, [title])
+            all_links.extend(page_links.get(title, []))
+            calls += 1
+            if "continue" not in data:
+                break
+            params["plcontinue"] = data["continue"]["plcontinue"]
+            params["continue"] = data["continue"]["continue"]
 
         return {title: all_links}
 
@@ -225,28 +301,20 @@ class WikipediaClient(WikipediaClientInterface):
         max_pages = max_paginate_calls
         calls = 0
 
-        try:
-            while calls < max_pages:
-                response = self.session.get(
-                    self.base_url, params=params, timeout=self.api_timeout
-                )
-                response.raise_for_status()
-                data = response.json()
-                backlinks = data.get("query", {}).get("backlinks", [])
-                all_backlinks.extend(
-                    bl["title"]
-                    for bl in backlinks
-                    if ":" not in bl.get("title", "")
-                    or bl.get("title", "").startswith("List of")
-                )
-                calls += 1
-                if "continue" not in data:
-                    break
-                params["blcontinue"] = data["continue"]["blcontinue"]
-                params["continue"] = data["continue"]["continue"]
-        except requests.RequestException as e:
-            logger.error(f"Wikipedia backlinks API request failed for '{title}': {e}")
-            raise WikipediaAPIError(f"API request failed: {e}")
+        while calls < max_pages:
+            data = self._request_with_backoff(params).json()
+            backlinks = data.get("query", {}).get("backlinks", [])
+            all_backlinks.extend(
+                bl["title"]
+                for bl in backlinks
+                if ":" not in bl.get("title", "")
+                or bl.get("title", "").startswith("List of")
+            )
+            calls += 1
+            if "continue" not in data:
+                break
+            params["blcontinue"] = data["continue"]["blcontinue"]
+            params["continue"] = data["continue"]["continue"]
 
         return {title: all_backlinks}
 

--- a/app/infrastructure/cache.py
+++ b/app/infrastructure/cache.py
@@ -14,13 +14,13 @@ class RedisCache(CacheServiceInterface):
     """Redis-based cache implementation."""
 
     def __init__(self, redis_client: redis.Redis, default_ttl: int = 86400):
-        self.redis_client = redis_client
+        self._redis_client = redis_client
         self.default_ttl = default_ttl
 
     def get(self, key: str) -> Any | None:
         """Get value from cache by key."""
         try:
-            value = self.redis_client.get(key)
+            value = self._redis_client.get(key)
             if value is None:
                 return None
             return json.loads(value)  # type: ignore[arg-type]
@@ -33,7 +33,7 @@ class RedisCache(CacheServiceInterface):
         try:
             ttl = ttl or self.default_ttl
             serialized_value = json.dumps(value)
-            self.redis_client.setex(key, ttl, serialized_value)
+            self._redis_client.setex(key, ttl, serialized_value)
         except (redis.RedisError, TypeError, ValueError) as e:
             logger.error(f"Failed to set value in cache for key {key}: {e}")
             raise CacheConnectionError(f"Cache set failed: {e}")
@@ -41,7 +41,7 @@ class RedisCache(CacheServiceInterface):
     def delete(self, key: str) -> None:
         """Delete key from cache."""
         try:
-            self.redis_client.delete(key)
+            self._redis_client.delete(key)
         except redis.RedisError as e:
             logger.error(f"Failed to delete key from cache: {key}: {e}")
             raise CacheConnectionError(f"Cache delete failed: {e}")
@@ -49,29 +49,17 @@ class RedisCache(CacheServiceInterface):
     def exists(self, key: str) -> bool:
         """Check if key exists in cache."""
         try:
-            return bool(self.redis_client.exists(key))
+            return bool(self._redis_client.exists(key))
         except redis.RedisError as e:
             logger.error(f"Failed to check key existence in cache: {key}: {e}")
             raise CacheConnectionError(f"Cache exists check failed: {e}")
-
-    def get_links_from_cache(self, page_title: str) -> list | None:
-        """Retrieves a list of links for a Wikipedia page from the cache."""
-        cache_key = f"wiki_links:{page_title}"
-        return self.get(cache_key)
-
-    def set_links_in_cache(
-        self, page_title: str, links: list, ttl: int | None = None
-    ) -> None:
-        """Stores a list of links for a page in the cache."""
-        cache_key = f"wiki_links:{page_title}"
-        self.set(cache_key, links, ttl)
 
     def delete_many(self, keys: list[str]) -> None:
         """Delete multiple keys in a single pipeline round-trip."""
         if not keys:
             return
         try:
-            with self.redis_client.pipeline() as pipe:
+            with self._redis_client.pipeline() as pipe:
                 for key in keys:
                     pipe.delete(key)
                 pipe.execute()
@@ -82,14 +70,14 @@ class RedisCache(CacheServiceInterface):
     def ping(self) -> bool:
         """Return True if Redis is reachable."""
         try:
-            return bool(self.redis_client.ping())
+            return bool(self._redis_client.ping())
         except redis.RedisError:
             return False
 
     def set_add(self, key: str, value: str) -> None:
         """Add a value to a Redis set."""
         try:
-            self.redis_client.sadd(key, value)
+            self._redis_client.sadd(key, value)
         except redis.RedisError as e:
             raise CacheConnectionError(f"set_add failed: {e}")
 
@@ -98,7 +86,7 @@ class RedisCache(CacheServiceInterface):
         if not values:
             return
         try:
-            with self.redis_client.pipeline() as pipe:
+            with self._redis_client.pipeline() as pipe:
                 for v in values:
                     pipe.sadd(key, v)
                 pipe.execute()
@@ -108,7 +96,7 @@ class RedisCache(CacheServiceInterface):
     def set_contains(self, key: str, value: str) -> bool:
         """Return True if value is a member of the set."""
         try:
-            return bool(self.redis_client.sismember(key, value))
+            return bool(self._redis_client.sismember(key, value))
         except redis.RedisError as e:
             raise CacheConnectionError(f"set_contains failed: {e}")
 
@@ -117,7 +105,7 @@ class RedisCache(CacheServiceInterface):
         if not values:
             return []
         try:
-            with self.redis_client.pipeline() as pipe:
+            with self._redis_client.pipeline() as pipe:
                 for v in values:
                     pipe.sismember(key, v)
                 return [bool(r) for r in pipe.execute()]
@@ -127,7 +115,7 @@ class RedisCache(CacheServiceInterface):
     def hash_set(self, key: str, field: str, value: str) -> None:
         """Set a field in a Redis hash."""
         try:
-            self.redis_client.hset(key, field, value)
+            self._redis_client.hset(key, field, value)
         except redis.RedisError as e:
             raise CacheConnectionError(f"hash_set failed: {e}")
 
@@ -136,7 +124,7 @@ class RedisCache(CacheServiceInterface):
         if not mapping:
             return
         try:
-            with self.redis_client.pipeline() as pipe:
+            with self._redis_client.pipeline() as pipe:
                 for field, value in mapping.items():
                     pipe.hset(key, field, value)
                 pipe.execute()
@@ -146,7 +134,7 @@ class RedisCache(CacheServiceInterface):
     def hash_get(self, key: str, field: str) -> str | None:
         """Get a field from a Redis hash. Returns None if missing."""
         try:
-            result = self.redis_client.hget(key, field)
+            result = self._redis_client.hget(key, field)
             if result is None:
                 return None
             return result.decode() if isinstance(result, bytes) else result  # type: ignore[union-attr]
@@ -156,39 +144,13 @@ class RedisCache(CacheServiceInterface):
     def clear_pattern(self, pattern: str) -> int:
         """Clear all keys matching a pattern."""
         try:
-            keys = self.redis_client.keys(pattern)
+            keys = self._redis_client.keys(pattern)
             if keys:
-                return self.redis_client.delete(*keys)  # type: ignore[return-value,arg-type]
+                return self._redis_client.delete(*keys)  # type: ignore[return-value,arg-type]
             return 0
         except redis.RedisError as e:
             logger.error(f"Failed to clear keys with pattern {pattern}: {e}")
             raise CacheConnectionError(f"Cache pattern clear failed: {e}")
-
-    def get_ttl(self, key: str) -> int:
-        """Get TTL for a key."""
-        try:
-            return self.redis_client.ttl(key)  # type: ignore[return-value]
-        except redis.RedisError as e:
-            logger.error(f"Failed to get TTL for key {key}: {e}")
-            return -1
-
-    def increment(self, key: str, amount: int = 1) -> int:
-        """Increment a numeric value in cache."""
-        try:
-            return self.redis_client.incrby(key, amount)  # type: ignore[return-value]
-        except redis.RedisError as e:
-            logger.error(f"Failed to increment key {key}: {e}")
-            raise CacheConnectionError(f"Cache increment failed: {e}")
-
-    def set_if_not_exists(self, key: str, value: Any, ttl: int | None = None) -> bool:
-        """Set value only if key doesn't exist."""
-        try:
-            ttl = ttl or self.default_ttl
-            serialized_value = json.dumps(value)
-            return bool(self.redis_client.set(key, serialized_value, ex=ttl, nx=True))
-        except (redis.RedisError, TypeError, ValueError) as e:
-            logger.error(f"Failed to set value if not exists for key {key}: {e}")
-            raise CacheConnectionError(f"Cache set if not exists failed: {e}")
 
 
 def get_redis_connection(redis_url: str) -> redis.Redis:

--- a/app/infrastructure/redis_queue.py
+++ b/app/infrastructure/redis_queue.py
@@ -14,30 +14,21 @@ class RedisQueue(QueueInterface):
     """Redis-based queue implementation for BFS pathfinding."""
 
     def __init__(self, redis_client: redis.Redis):
-        self.redis_client = redis_client
+        self._redis_client = redis_client
 
     def push(self, queue_name: str, item: Any) -> None:
         """Push item to the right side of the queue (FIFO)."""
         try:
             serialized_item = json.dumps(item)
-            self.redis_client.rpush(queue_name, serialized_item)
+            self._redis_client.rpush(queue_name, serialized_item)
         except (redis.RedisError, TypeError, ValueError) as e:
             logger.error(f"Failed to push item to queue {queue_name}: {e}")
             raise CacheConnectionError(f"Queue push failed: {e}")
 
-    def push_front(self, queue_name: str, item: Any) -> None:
-        """Push item to the front (left side) of the queue."""
-        try:
-            serialized_item = json.dumps(item)
-            self.redis_client.lpush(queue_name, serialized_item)
-        except (redis.RedisError, TypeError, ValueError) as e:
-            logger.error(f"Failed to push item to front of queue {queue_name}: {e}")
-            raise CacheConnectionError(f"Queue push front failed: {e}")
-
     def pop(self, queue_name: str) -> Any | None:
         """Pop item from the left side of the queue (FIFO)."""
         try:
-            item = self.redis_client.lpop(queue_name)
+            item = self._redis_client.lpop(queue_name)
             if item is None:
                 return None
             return json.loads(item)  # type: ignore[arg-type]
@@ -48,7 +39,7 @@ class RedisQueue(QueueInterface):
     def length(self, queue_name: str) -> int:
         """Get the length of the queue."""
         try:
-            return self.redis_client.llen(queue_name)  # type: ignore[return-value]
+            return self._redis_client.llen(queue_name)  # type: ignore[return-value]
         except redis.RedisError as e:
             logger.error(f"Failed to get queue length for {queue_name}: {e}")
             raise CacheConnectionError(f"Queue length check failed: {e}")
@@ -56,7 +47,7 @@ class RedisQueue(QueueInterface):
     def clear(self, queue_name: str) -> None:
         """Clear all items from the queue."""
         try:
-            self.redis_client.delete(queue_name)
+            self._redis_client.delete(queue_name)
         except redis.RedisError as e:
             logger.error(f"Failed to clear queue {queue_name}: {e}")
             raise CacheConnectionError(f"Queue clear failed: {e}")
@@ -67,7 +58,7 @@ class RedisQueue(QueueInterface):
             return
 
         try:
-            with self.redis_client.pipeline() as pipe:
+            with self._redis_client.pipeline() as pipe:
                 for item in items:
                     pipe.rpush(queue_name, json.dumps(item))
                 pipe.execute()
@@ -81,7 +72,7 @@ class RedisQueue(QueueInterface):
             return []
 
         try:
-            with self.redis_client.pipeline() as pipe:
+            with self._redis_client.pipeline() as pipe:
                 for _ in range(count):
                     pipe.lpop(queue_name)
                 results = pipe.execute()
@@ -89,14 +80,3 @@ class RedisQueue(QueueInterface):
         except (redis.RedisError, json.JSONDecodeError) as e:
             logger.error(f"Failed to pop batch from queue {queue_name}: {e}")
             raise CacheConnectionError(f"Queue batch pop failed: {e}")
-
-    def peek(self, queue_name: str, index: int = 0) -> Any | None:
-        """Peek at an item in the queue without removing it."""
-        try:
-            item = self.redis_client.lindex(queue_name, index)
-            if item is None:
-                return None
-            return json.loads(item)  # type: ignore[arg-type]
-        except (redis.RedisError, json.JSONDecodeError) as e:
-            logger.error(f"Failed to peek at queue {queue_name}: {e}")
-            return None

--- a/app/infrastructure/tasks.py
+++ b/app/infrastructure/tasks.py
@@ -20,8 +20,6 @@ logger = get_logger(__name__)
     bind=True,
     autoretry_for=(requests.RequestException, CacheConnectionError, WikipediaAPIError),
     retry_kwargs={"max_retries": 3, "countdown": 60},
-    soft_time_limit=300,  # 5 minutes
-    time_limit=600,  # 10 minutes
 )
 def find_path_task(
     self, start_page: str, end_page: str, algorithm: str = "bidirectional"
@@ -345,17 +343,9 @@ def configure_task_routes(app):
         "app.infrastructure.tasks.cache_cleanup_task": {"queue": "maintenance"},
     }
 
-    # Task time limits
-    app.conf.task_time_limit = 600  # 10 minutes hard limit
-    app.conf.task_soft_time_limit = 300  # 5 minutes soft limit
-
     # Task result settings
     app.conf.result_expires = 3600  # Results expire after 1 hour
     app.conf.result_persistent = True
-
-    # Task execution settings
-    app.conf.task_acks_late = True
-    app.conf.worker_prefetch_multiplier = 1
 
     # Task retry settings
     app.conf.task_reject_on_worker_lost = True

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -131,20 +131,6 @@ class TaskError(IrisBaseException):
         super().__init__(message, "TASK_ERROR")
 
 
-class TaskTimeoutError(TaskError):
-    """Raised when a task times out."""
-
-    def __init__(self, task_id: str | None = None, timeout: int | None = None):
-        message = "Task timed out"
-        if task_id:
-            message = f"Task {task_id} timed out"
-        if timeout:
-            message += f" after {timeout} seconds"
-        super().__init__(message, task_id)
-        self.timeout = timeout
-        self.code = "TASK_TIMEOUT"
-
-
 class ConfigurationError(IrisBaseException):
     """Raised when configuration is invalid or missing."""
 

--- a/config/base.py
+++ b/config/base.py
@@ -21,17 +21,27 @@ class BaseConfig:
 
     # Wikipedia API settings
     WIKIPEDIA_API_TIMEOUT = int(os.environ.get("WIKIPEDIA_API_TIMEOUT", "15"))
-    WIKIPEDIA_MAX_WORKERS = int(os.environ.get("WIKIPEDIA_MAX_WORKERS", "10"))
+    WIKIPEDIA_MAX_WORKERS = int(os.environ.get("WIKIPEDIA_MAX_WORKERS", "3"))
     WIKIPEDIA_MAX_PAGINATE_CALLS = int(
-        os.environ.get("WIKIPEDIA_MAX_PAGINATE_CALLS", "10")
+        os.environ.get("WIKIPEDIA_MAX_PAGINATE_CALLS", "3")
+    )
+    WIKIPEDIA_REQUEST_DELAY = float(os.environ.get("WIKIPEDIA_REQUEST_DELAY", "0.1"))
+    WIKIPEDIA_BACKOFF_MAX_RETRIES = int(
+        os.environ.get("WIKIPEDIA_BACKOFF_MAX_RETRIES", "5")
     )
 
     # Cache settings
-    CACHE_TTL = int(os.environ.get("CACHE_TTL", "86400"))  # 24 hours
+    CACHE_TTL = int(os.environ.get("CACHE_TTL", "86400"))  # 24 hours — Wikipedia links
+    CACHE_PATH_TTL = int(
+        os.environ.get("CACHE_PATH_TTL", "3600")
+    )  # 1 hour — pathfinding results
+    CACHE_PAGE_TTL = int(
+        os.environ.get("CACHE_PAGE_TTL", "7200")
+    )  # 2 hours — Wikipedia page info
 
     # Pathfinding settings
     MAX_SEARCH_DEPTH = int(os.environ.get("MAX_SEARCH_DEPTH", "6"))
-    BFS_BATCH_SIZE = int(os.environ.get("BFS_BATCH_SIZE", "50"))
+    BFS_BATCH_SIZE = int(os.environ.get("BFS_BATCH_SIZE", "20"))
 
     # Celery settings
     CELERY_BROKER_URL = REDIS_URL

--- a/docs/architecture_guide.tex
+++ b/docs/architecture_guide.tex
@@ -154,36 +154,36 @@
 \begin{titlepage}
     \centering
     \vspace*{2cm}
-    
+
     {\Huge\bfseries\color{accentblue} Iris Backend\\[0.3cm] Architecture Guide}
-    
+
     \vspace{1cm}
-    
+
     {\Large Wikipedia Pathfinding Engine}
-    
+
     \vspace{2cm}
-    
+
     \begin{tikzpicture}[
         layer/.style={draw, rounded corners, minimum width=11cm, minimum height=1.2cm, align=center, font=\small},
         arrow/.style={->, thick, >=stealth}
     ]
         \node[layer, fill=accentblue!20] (api) at (0,4) {\textbf{HTTP API Layer} (routes.py)\\Receives requests $\rightarrow$ Validates $\rightarrow$ Delegates};
         \node[layer, fill=accentgreen!20] (services) at (0,2) {\textbf{Business Services Layer} (services.py)\\Orchestrates operations $\rightarrow$ Uses pathfinders $\rightarrow$ Caching};
-        \node[layer, fill=warningorange!20] (core) at (0,0) {\textbf{Core Domain Layer} (pathfinding.py)\\Contains CORE ALGORITHM (BFS, Bidirectional BFS)};
+        \node[layer, fill=warningorange!20] (core) at (0,0) {\textbf{Core Domain Layer} (pathfinding.py)\\BFS + Bidirectional BFS with Redis-based state};
         \node[layer, fill=codegray!20] (infra) at (0,-2) {\textbf{Infrastructure Layer}\\Redis cache, Redis queue, Celery tasks, Wikipedia API};
-        
+
         \draw[arrow] (api) -- (services);
         \draw[arrow] (services) -- (core);
         \draw[arrow] (core) -- (infra);
     \end{tikzpicture}
-    
+
     \vspace{2cm}
-    
+
     {\large Interview Preparation \& Development Reference}
-    
+
     \vfill
-    
-    {\large Last Updated: January 2026}
+
+    {\large Last Updated: March 2026}
 \end{titlepage}
 
 % ============================================
@@ -212,7 +212,7 @@ iris-web-backend/
 |   |   |-- factory.py           # Dependency Injection (ServiceFactory)
 |   |   |-- interfaces.py        # Abstract interfaces (contracts)
 |   |   |-- models.py            # Data models (dataclasses)
-|   |   |-- pathfinding.py       # CORE ALGORITHM (BFS)
+|   |   |-- pathfinding.py       # CORE ALGORITHM (BFS + Bidirectional BFS)
 |   |   |-- services.py          # Business services orchestration
 |   |-- external/                # External API integrations
 |   |   |-- wikipedia.py         # Wikipedia API client
@@ -225,6 +225,9 @@ iris-web-backend/
 |       |-- logging.py           # Logging configuration
 |-- config/                      # Configuration classes
 |-- tests/                       # Test suites
+|   |-- conftest.py              # Shared fixtures (stateful mocks)
+|   |-- unit/                    # Unit tests (per-class)
+|   |-- integration/             # Integration tests (service interactions)
 |-- run.py                       # Application entry point
 |-- celery_worker.py             # Celery worker entry point
 \end{lstlisting}
@@ -245,14 +248,14 @@ Layer & Responsibility \\
 HTTP API Layer \newline \footnotesize\texttt{app/api/} &
 Receives HTTP requests, validates input using Marshmallow schemas, applies cross-cutting middleware (CORS, logging, error handling), delegates to business services, and formats JSON responses. Swagger spec is auto-assembled from YAML docstrings on each route function via Flasgger. \\
 \addlinespace[0.5em]
-Business Services \newline \footnotesize\texttt{app/core/services.py} & 
-Orchestrates business operations. Checks cache before invoking pathfinding, coordinates between pathfinders and Wikipedia client, encapsulates use cases like ``find path'' or ``explore page.'' \\
+Business Services \newline \footnotesize\texttt{app/core/services.py} &
+Orchestrates business operations. Checks cache before invoking pathfinding, coordinates between pathfinders and Wikipedia client, encapsulates use cases like ``find path'' or ``get page info.'' \\
 \addlinespace[0.5em]
-Core Domain \newline \footnotesize\texttt{app/core/pathfinding.py} & 
-Contains the pure BFS algorithm. No knowledge of HTTP, Redis, or Flask. Only knows about abstract interfaces. This is where the graph traversal logic lives. \\
+Core Domain \newline \footnotesize\texttt{app/core/pathfinding.py} &
+Contains the BFS and Bidirectional BFS algorithms. No knowledge of HTTP or Flask. Only knows about abstract interfaces. This is where the graph traversal logic lives. \\
 \addlinespace[0.5em]
-Infrastructure \newline \footnotesize\texttt{app/infrastructure/} & 
-Concrete implementations: Redis cache, Redis queue for BFS state, Celery tasks for background processing, Wikipedia API client. All ``how'' details live here. \\
+Infrastructure \newline \footnotesize\texttt{app/infrastructure/} &
+Concrete implementations: Redis cache, Redis queue for BFS state, Celery tasks for background processing. Also \texttt{app/external/wikipedia.py} for the Wikipedia API client. All ``how'' details live here. \\
 \bottomrule
 \end{tabularx}
 
@@ -272,7 +275,7 @@ Concrete implementations: Redis cache, Redis queue for BFS state, Celery tasks f
     \node[box, fill=warningorange!20, below=of services] (pathfinding) {pathfinding.py};
     \node[box, fill=codegray!20, left=of pathfinding] (wikipedia) {wikipedia.py};
     \node[box, fill=codegray!20, right=of pathfinding] (redis) {Redis};
-    
+
     \draw[arrow] (client) -- (routes);
     \draw[arrow] (routes) -- (middleware);
     \draw[arrow] (middleware) -- (celery);
@@ -353,7 +356,7 @@ This section justifies key technical decisions from a \textbf{distributed system
 \begin{decisionbox}{Redis-Based BFS Queue with Batch Node Processing}
 \textbf{Problem:} BFS at depth 5+ can involve millions of nodes. Python's \texttt{deque} would exhaust worker memory. Fetching links one node at a time also wastes Wikipedia API capacity.
 
-\textbf{Decision:} Store BFS queue and visited set in Redis. Each iteration pops a \textbf{batch} of nodes (\texttt{BFS\_BATCH\_SIZE}, default 50) and fetches all their links in a single \texttt{get\_links\_bulk} call.
+\textbf{Decision:} Store BFS queue and visited set in Redis. Each iteration pops a \textbf{batch} of nodes (\texttt{BFS\_BATCH\_SIZE}, default 50) and fetches all their links in a single \texttt{get\_links\_bulk} call which fans out to N parallel Wikipedia requests.
 
 \textbf{Engineering Justification:}
 \begin{itemize}[leftmargin=*, nosep]
@@ -379,34 +382,53 @@ This section justifies key technical decisions from a \textbf{distributed system
 \end{itemize}
 \end{decisionbox}
 
-\begin{decisionbox}{Wikipedia API Fetching: One Request Per Page}
+\begin{decisionbox}{Wikipedia API Fetching: One Request Per Page, with Pagination}
 \textbf{Problem:} Wikipedia's \texttt{prop=links} API returns at most 500 links per request (\texttt{pllimit=max}). This cap is \textbf{global per API call}, not per title. Grouping multiple titles in one request causes link starvation: a high-link-count hub page (e.g.\ \textit{Microsoft} with 500+ links) consumes the entire 500-link quota, leaving other pages in the same request with 0 links returned.
 
-\textbf{Decision:} Each page title is fetched in its own API call. Parallelism is preserved via \texttt{ThreadPoolExecutor} (\texttt{WIKIPEDIA\_MAX\_WORKERS}, default: 10), so a BFS batch of 50 nodes still issues all 50 requests concurrently.
+\textbf{Decision:} Each page title is fetched in its own API call. Parallelism is preserved via \texttt{ThreadPoolExecutor} (\texttt{WIKIPEDIA\_MAX\_WORKERS}, default: 10), so a BFS batch of 50 nodes still issues all 50 requests concurrently. Pagination is followed up to \texttt{WIKIPEDIA\_MAX\_PAGINATE\_CALLS} (default: 3) pages per title, yielding up to $3 \times 500 = 1{,}500$ links per page before truncating.
 
 \textbf{Engineering Justification:}
 \begin{itemize}[leftmargin=*, nosep]
-    \item \textbf{Correctness:} Every page receives its full 500-link allocation regardless of what other pages are in the same BFS batch.
+    \item \textbf{Correctness:} Every page receives its full link allocation regardless of what other pages are in the same BFS batch.
     \item \textbf{I/O Bound:} Wikipedia API calls are network-bound; threads maximise throughput without the starvation risk of multi-title requests.
-    \item \textbf{Rate Limiting:} Thread pool size implicitly caps concurrent requests to Wikipedia.
+    \item \textbf{Rate Limiting:} Thread pool size implicitly caps concurrent requests to Wikipedia. A shared \texttt{threading.Lock}-guarded rate limiter enforces a minimum interval between all requests across threads.
 \end{itemize}
 
-\textbf{Known Limitation:} Wikipedia paginates beyond 500 links via a \texttt{continue} token. This implementation does \textbf{not} follow pagination; only the first 500 outgoing links of any page are explored. For most articles this is sufficient, but high-connectivity hub pages may have paths that pass through links beyond the first 500. This is a conscious trade-off: following pagination would multiply API calls for hub pages and add latency for marginal accuracy gain.
+\textbf{Backoff Strategy:} \texttt{\_request\_with\_backoff} retries up to \texttt{max\_retries} (default: 5) times with exponential backoff ($2^{attempt}$ seconds). HTTP 429 responses honour the \texttt{Retry-After} header. 5xx server errors trigger the same backoff. Other 4xx errors raise \texttt{WikipediaAPIError} immediately without retry.
 \end{decisionbox}
 
-\begin{decisionbox}{Why Bidirectional BFS Was Abandoned}
-\textbf{Problem:} Bidirectional BFS works by expanding two frontiers simultaneously — one from the start and one from the end — and halting when they meet. This can reduce search space from $O(b^d)$ to $O(b^{d/2})$ in uniform graphs.
+\begin{decisionbox}{Bidirectional BFS using Wikipedia Backlinks}
+\textbf{Idea:} Standard BFS expands one frontier from the start page. Bidirectional BFS expands \textbf{two} frontiers simultaneously --- one forward from the start and one backward from the end --- and stops when they meet. Theoretical speedup: $O(b^{d/2})$ vs $O(b^d)$.
 
-\textbf{Why It Fails for Wikipedia:}
+\textbf{How the reverse frontier works in Wikipedia:} The backward frontier needs to know ``which pages link \emph{to} the current target?'' This is Wikipedia's \texttt{prop=linkshere} API (``what links here''). The \texttt{get\_backlinks\_bulk} method calls this API, caching results under the \texttt{wiki\_backlinks:} key prefix.
+
+\textbf{Algorithm (\texttt{BidirectionalBFSPathFinder}):}
+\begin{enumerate}[leftmargin=*, nosep]
+    \item Initialise \texttt{fwd\_queue} with \texttt{start\_page} (depth 0) and \texttt{bwd\_queue} with \texttt{end\_page} (depth 0).
+    \item Each iteration: expand whichever frontier is \textbf{smaller} (load balancing). Forward expands by following outgoing links; backward expands by following backlinks.
+    \item Visited sets (\texttt{fwd\_visited}, \texttt{bwd\_visited}) are Redis sets. Batch membership checks use \texttt{set\_contains\_many} (one pipeline round-trip).
+    \item When a newly discovered node is already in the \textit{opposite} frontier's visited set, that node is a \textbf{meeting point}.
+    \item If multiple meeting points are found in one batch, \texttt{\_pick\_shortest} selects the one whose combined forward+backward path length is shortest.
+    \item Path reconstruction: \texttt{\_reconstruct\_path(meeting, fwd\_par)} walks forward parent hashes from meeting back to start. \texttt{\_reconstruct\_bwd\_chain(meeting, bwd\_par)} walks backward parent hashes from meeting forward to end. The two segments are concatenated.
+\end{enumerate}
+
+\textbf{Depth budget:} \texttt{fwd\_max = (max\_depth + 1) // 2}, \texttt{bwd\_max = max\_depth // 2}. Each frontier stops expanding at its budget.
+
+\textbf{Trade-off:} Backlinks for very popular pages (e.g. ``United States'') can return extremely large result sets, making the backward frontier expensive. The ``expand smaller frontier'' heuristic mitigates this by deprioritising large frontiers. In the worst case (highly asymmetric graph), standard BFS may still be faster; in practice the algorithm often halves search depth.
+\end{decisionbox}
+
+\begin{decisionbox}{BidirProgressAggregator: Thread-Safe Dual-Frontier Progress}
+\textbf{Problem:} Two frontiers run concurrently (both call \texttt{get\_links\_bulk} / \texttt{get\_backlinks\_bulk} which fire \texttt{on\_page\_fetched} from worker threads). A single progress callback must receive unified stats without race conditions.
+
+\textbf{Decision:} \texttt{BidirProgressAggregator} owns all shared counters under one \texttt{threading.Lock}. Each frontier calls \texttt{aggregator.record(title, depth, direction)} from its \texttt{on\_page\_fetched} closure. The aggregator increments the appropriate counter, reads both queue sizes in one call, and fires the real callback with a unified snapshot.
+
+\textbf{What it tracks:}
 \begin{itemize}[leftmargin=*, nosep]
-    \item Wikipedia link graphs are \textbf{highly asymmetric}. A page like \textit{Adolf Hitler} has thousands of \textbf{incoming} links but only hundreds of \textbf{outgoing} links.
-    \item The reverse frontier (expanding backward from the target via incoming links) requires fetching ``what links here'' — a separate Wikipedia API call (\texttt{prop=linkshere}) that returns far larger result sets.
-    \item The reverse frontier explodes in size immediately, eliminating any search space reduction and typically making the search \textbf{slower} than standard BFS.
+    \item \texttt{\_fwd\_nodes}, \texttt{\_bwd\_nodes} --- separate node counts per direction.
+    \item \texttt{total\_nodes} property --- their sum.
+    \item \texttt{queue\_size} in the callback --- sum of both frontier queue lengths.
+    \item \texttt{direction} field --- lets the UI indicate which frontier found the node.
 \end{itemize}
-
-\textbf{Decision:} Retain only forward BFS. The \texttt{BidirectionalBFSPathFinder} class exists in the codebase and is selectable via the API \texttt{algorithm} parameter, but it delegates directly to \texttt{RedisBasedBFSPathFinder}. The \texttt{algorithm} field is kept in the API for forward compatibility.
-
-\textbf{Trade-off:} Forward BFS with Wikipedia's dense link graph typically finds paths of length 3--5 within seconds. The asymmetry that breaks bidirectional BFS is also what makes forward BFS fast.
 \end{decisionbox}
 
 \begin{decisionbox}{Cache TTLs Tuned to Data Volatility}
@@ -416,21 +438,21 @@ This section justifies key technical decisions from a \textbf{distributed system
 
 \textbf{Engineering Justification:}
 \begin{itemize}[leftmargin=*, nosep]
-    \item \texttt{wiki\_links:*} -- 24 hours. Page links rarely change; high reuse value.
+    \item \texttt{wiki\_links:*} and \texttt{wiki\_backlinks:*} -- 24 hours. Page links rarely change; high reuse value.
     \item \texttt{path:*:*} -- 1 hour. Paths are computed results; shorter TTL ensures freshness.
-    \item \texttt{bfs\_*} -- 1 hour with explicit cleanup. Ephemeral search state; cleaned after use.
+    \item \texttt{bfs\_*} -- explicit cleanup after search completes (not TTL-based). Periodic maintenance task sweeps orphaned keys.
 \end{itemize}
 \end{decisionbox}
 
 \begin{decisionbox}{UUID-Based Session Isolation for BFS State}
 \textbf{Problem:} Multiple concurrent searches must not interfere with each other's BFS state.
 
-\textbf{Decision:} Each search generates a UUID. All Redis keys are prefixed: \texttt{bfs\_queue:<uuid>}, \texttt{bfs\_visited:<uuid>:*}.
+\textbf{Decision:} Each search generates a UUID. All Redis keys are prefixed: \texttt{bfs\_queue:<uuid>}, \texttt{bfs\_visited:<uuid>}, \texttt{bfs\_parent:<uuid>}.
 
 \textbf{Engineering Justification:}
 \begin{itemize}[leftmargin=*, nosep]
     \item \textbf{No Locking Required:} Each search operates on its own keyspace.
-    \item \textbf{Easy Cleanup:} Pattern-based deletion: \texttt{DEL bfs\_*:<uuid>:*}.
+    \item \textbf{Easy Cleanup:} Pattern-based deletion via \texttt{delete\_many} in a \texttt{finally} block --- guaranteed to run even if search fails.
     \item \textbf{Debugging:} Can trace a specific search by its UUID in logs and Redis.
 \end{itemize}
 \end{decisionbox}
@@ -460,7 +482,7 @@ API Request Rate & Add more Flask/Gunicorn instances behind load balancer. \\
 \addlinespace[0.3em]
 Cache Size & Redis Cluster with sharding or increase instance memory. \\
 \addlinespace[0.3em]
-Wikipedia Rate Limits & Configurable thread pool; add delay; use multiple API keys. \\
+Wikipedia Rate Limits & Configurable thread pool; request delay; exponential backoff. \\
 \addlinespace[0.3em]
 Storage (Results) & Redis with TTL-based eviction; results auto-expire after 1 hour. \\
 \bottomrule
@@ -490,11 +512,13 @@ Component & Lifecycle & Reasoning \\
 \midrule
 Redis Client & Singleton & Maintains \texttt{ConnectionPool}; avoids TCP handshake overhead per request. \\
 \addlinespace[0.3em]
-Wikipedia Client & Singleton & Holds \texttt{requests.Session}; enables HTTP Keep-Alive and TLS session reuse. \\
+Wikipedia Client & Singleton & Holds \texttt{requests.Session}; enables HTTP Keep-Alive and TLS session reuse. Also owns the rate-limiter lock and last-request timestamp. \\
 \addlinespace[0.3em]
 Cache Service & Singleton & Shared serialization logic wrapping the Redis client. \\
 \addlinespace[0.3em]
-Pathfinding Service & Transient & New instance per task. Allows request-specific \texttt{progress\_callback} and algorithm. \\
+Queue Service & Singleton & Shared FIFO queue wrapping the same Redis client. \\
+\addlinespace[0.3em]
+Pathfinding Service & Transient & New instance per task. Allows request-specific \texttt{progress\_callback} and algorithm choice. \\
 \bottomrule
 \end{tabularx}
 
@@ -537,8 +561,8 @@ A BFS search can take minutes. Without progress updates, the client has no idea:
     \item \textbf{Task creates a callback function} that updates Celery task state.
     \item \textbf{Callback is injected} into \texttt{PathFindingService} via constructor.
     \item \textbf{BFS passes an \texttt{on\_page\_fetched} closure} into \texttt{get\_links\_bulk}.
-    \item \textbf{Wikipedia client fires the closure} from worker threads as each API response arrives.
-    \item \textbf{Client polls} \texttt{/tasks/status/<id>} and sees real-time progress spread across the fetch window.
+    \item \textbf{Wikipedia client fires the closure} from worker threads as each API response arrives (and also for cache hits), spreading updates across the fetch window.
+    \item \textbf{Client polls} \texttt{/tasks/status/<id>} and sees real-time progress.
 \end{enumerate}
 
 \subsection{Code Flow}
@@ -547,21 +571,22 @@ A BFS search can take minutes. Without progress updates, the client has no idea:
 
 \begin{lstlisting}[caption=tasks.py -- Creating the Progress Callback]
 @celery.task(bind=True)
-def find_path_task(self, start_page, end_page, algorithm="bfs"):
-    
-    # Define a closure that captures 'self' (the Celery task)
+def find_path_task(self, start_page, end_page, algorithm="bidirectional"):
+    max_depth = current_app.config.get("MAX_SEARCH_DEPTH", 6)
+
     def progress_update(progress_data):
-        self.update_state(
-            state="PROGRESS",
-            meta=progress_data  # Contains nodes_explored, current_depth, etc.
-        )
-    
-    # Pass the callback to the service factory
-    pathfinding_service = get_pathfinding_service(
-        algorithm=algorithm,
-        progress_callback=progress_update  # <-- Injected here
-    )
-    
+        # Normalise: pathfinders may emit a flat dict or one with search_stats
+        if "search_stats" not in progress_data:
+            progress_data = {
+                "status": "Searching...",
+                "search_stats": progress_data,
+            }
+        progress_data["search_stats"].setdefault("start_page", start_page)
+        progress_data["search_stats"].setdefault("end_page", end_page)
+        progress_data["search_stats"].setdefault("max_depth", max_depth)
+        self.update_state(state="PROGRESS", meta=progress_data)
+
+    pathfinding_service = get_pathfinding_service(algorithm, progress_update)
     result = pathfinding_service.find_path(search_request)
 \end{lstlisting}
 
@@ -569,113 +594,134 @@ def find_path_task(self, start_page, end_page, algorithm="bfs"):
 
 \begin{lstlisting}[caption=factory.py -- Injecting the Callback]
 @classmethod
-def create_pathfinding_service(cls, algorithm="bfs", progress_callback=None):
-    # ... get singletons ...
-    
-    path_finder = RedisBasedBFSPathFinder(
-        wikipedia_client,
-        cache_service,
-        queue_service,
-        max_depth,
-        batch_size,
-        progress_callback  # <-- Passed to the algorithm
-    )
-    
+def create_pathfinding_service(cls, algorithm="bidirectional", progress_callback=None):
+    wikipedia_client = cls.get_wikipedia_client()
+    cache_service = cls.get_cache_service()
+    queue_service = cls.get_queue_service()
+    max_depth = current_app.config.get("MAX_SEARCH_DEPTH", 6)
+    batch_size = current_app.config.get("BFS_BATCH_SIZE", 50)
+
+    if algorithm.lower() == "bidirectional":
+        path_finder = BidirectionalBFSPathFinder(
+            wikipedia_client, cache_service, queue_service,
+            max_depth, batch_size, progress_callback
+        )
+    else:
+        path_finder = RedisBasedBFSPathFinder(
+            wikipedia_client, cache_service, queue_service,
+            max_depth, batch_size, progress_callback
+        )
+
     return PathFindingService(path_finder, cache_service, wikipedia_client)
 \end{lstlisting}
 
-\subsubsection{Step 3: BFS Passes a Closure into the Wikipedia Fetch}
+\subsubsection{Step 3: BFS Defines an \texttt{on\_page\_fetched} Closure}
 
-Rather than firing all progress updates before the Wikipedia API call (which bunches them into a tight loop invisible to polling clients), BFS defines an \texttt{on\_page\_fetched} closure and passes it into \texttt{get\_links\_bulk}.  The Wikipedia client fires this closure \textbf{from worker threads} as each individual HTTP response arrives via \texttt{as\_completed}, spreading updates naturally across the network round-trip window.
+\begin{lstlisting}[caption=pathfinding.py -- on\_page\_fetched Closure (RedisBasedBFS)]
+nodes_explored = 0
+nodes_lock = threading.Lock()   # guards concurrent increments from thread pool
 
-\begin{lstlisting}[caption=pathfinding.py -- on\_page\_fetched Closure]
-def _perform_bfs_search(self, start_page, end_page, ...):
-    nodes_explored = 0
-    nodes_lock = threading.Lock()  # guards against concurrent increments
+while self.queue_service.length(queue_key) > 0:
+    batch_items = self.queue_service.pop_batch(queue_key, self.batch_size)
+    current_depth = batch_items[0]["depth"]
 
-    while self.queue_service.length(queue_key) > 0:
-        batch_items = self.queue_service.pop_batch(queue_key, self.batch_size)
-        current_depth = batch_items[0]["depth"]
+    on_page_fetched: Callable | None = None
+    if self.progress_callback:
+        def _on_page_fetched(title, _links, *, _d=current_depth):
+            # Default arg binds current_depth by VALUE at def time (avoids B023 late-binding).
+            # Called concurrently from ThreadPoolExecutor threads.
+            nonlocal nodes_explored
+            with nodes_lock:
+                nodes_explored += 1
+                count = nodes_explored
+            self.progress_callback({
+                "status": "Searching...",
+                "search_stats": {
+                    "nodes_explored": count,
+                    "current_depth": _d,
+                    "last_node": title,
+                    "queue_size": self.queue_service.length(queue_key),
+                },
+                "search_time_elapsed": round(time.time() - search_start_time, 2),
+            })
+        on_page_fetched = _on_page_fetched
 
-        # Pre-declare so the type-checker sees Callable | None across branches.
-        on_page_fetched: Callable[[str, list[str]], None] | None = None
-        if self.progress_callback:
-
-            def _on_page_fetched(
-                title: str,
-                _links: list[str],
-                *,
-                _d: int = current_depth,  # default arg binds value at def time
-            ) -> None:
-                nonlocal nodes_explored
-                with nodes_lock:
-                    nodes_explored += 1
-                    count = nodes_explored
-                self.progress_callback({
-                    "status": "Searching...",
-                    "search_stats": {
-                        "nodes_explored": count,
-                        "current_depth": _d,
-                        "last_node": title,
-                        # NOTE: stale within batch -- see note below
-                        "queue_size": self.queue_service.length(queue_key),
-                    },
-                    "search_time_elapsed": round(time.time() - start_time, 2),
-                })
-
-            on_page_fetched = _on_page_fetched
-
-        # on_page_fetched fires inside the thread pool as each page resolves
-        links_bulk = self.wikipedia_client.get_links_bulk(
-            [item["page"] for item in batch_items], on_page_fetched
-        )
-        # ... process each page's links ...
+    links_bulk = self.wikipedia_client.get_links_bulk(page_names, on_page_fetched)
+    # When no progress callback: increment counter here instead of in the closure.
+    if on_page_fetched is None:
+        nodes_explored += len(batch_items)
 \end{lstlisting}
 
-\begin{lstlisting}[caption=wikipedia.py -- Firing the Callback via as\_completed]
-def _fetch_from_wikipedia(self, page_titles, on_page_fetched=None):
+\subsubsection{Step 4: Wikipedia Client Fires the Closure via \texttt{as\_completed}}
+
+\begin{lstlisting}[caption=wikipedia.py -- \_bulk\_fetch firing on\_page\_fetched]
+def _bulk_fetch(self, page_titles, cache_prefix, fetch_fn, on_page_fetched):
     results = {}
+    uncached_titles = []
+
+    # Cache hits fire the callback immediately
+    if self.cache_service:
+        for title in page_titles:
+            cached = self.cache_service.get(f"{cache_prefix}:{title}")
+            if cached is not None:
+                results[title] = cached
+                if on_page_fetched:
+                    on_page_fetched(title, cached)   # fires for cache hit too
+            else:
+                uncached_titles.append(title)
+
+    # Cache misses: parallel fetch with as_completed
     with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
         future_to_title = {
-            executor.submit(self._fetch_single_page, title): title
-            for title in page_titles
+            executor.submit(bound_fetch_fn, title): title
+            for title in uncached_titles
         }
         for future in as_completed(future_to_title):
             title = future_to_title[future]
-            page_result = future.result()
+            page_result = future.result()   # raises WikipediaAPIError on failure
             results.update(page_result)
             if on_page_fetched:
                 on_page_fetched(title, page_result.get(title, []))
+
+    # Cache fresh results
+    for title, links in fresh_results.items():
+        self.cache_service.set(f"{cache_prefix}:{title}", links, ttl=self.cache_ttl)
     return results
 \end{lstlisting}
 
-\noindent\textbf{Why this works:} With \texttt{executor.map} all results are collected before returning, so callbacks would still bunch together.  \texttt{as\_completed} yields each future the moment its HTTP response arrives --- progress updates are spread across the \textasciitilde500--2000\,ms fetch window, giving the polling client genuinely smooth feedback.
+\noindent\textbf{Why \texttt{as\_completed} instead of \texttt{executor.map}:} \texttt{map} collects all results before yielding, so callbacks would bunch together at the end. \texttt{as\_completed} yields each future the moment its HTTP response arrives --- updates are spread across the 500--2000\,ms fetch window, giving the polling client genuinely smooth feedback.
 
-\noindent\textbf{Thread safety:} \texttt{on\_page\_fetched} is called concurrently from multiple worker threads.  \texttt{nodes\_lock} (a \texttt{threading.Lock}) ensures \texttt{nodes\_explored} is incremented atomically.  \texttt{update\_state} writes to Redis, which is inherently thread-safe.
+\noindent\textbf{Why cache hits also fire the callback:} If most of a batch is cached, the thread pool finishes almost instantly and the callback would never fire. Firing for cache hits ensures the client always gets progress updates even in warm-cache scenarios.
 
-\noindent\textbf{Loop variable capture (B023):} Python closures capture variables by reference, not by value. If \texttt{current\_depth} were referenced as a free variable inside the closure, all threads would see whatever value it holds when they \emph{execute}, not when the closure was \emph{defined} --- a classic late-binding bug. Binding it as a keyword-only default argument (\texttt{\_d=current\_depth}) forces evaluation at definition time, making each iteration's closure hold its own snapshot of the depth.
+\noindent\textbf{Thread safety:} \texttt{on\_page\_fetched} is called concurrently from multiple worker threads. \texttt{nodes\_lock} ensures \texttt{nodes\_explored} is incremented atomically. \texttt{update\_state} writes to Redis, which is inherently thread-safe.
 
-\noindent\textbf{Queue size during the fetch phase is stale.}  \texttt{on\_page\_fetched} fires \emph{during} the Wikipedia fetch, before the link-processing loop has pushed any new nodes.  The \texttt{queue\_size} at that point reflects the queue after \texttt{pop\_batch} removed the current batch but before any new discoveries are enqueued — it will read lower than reality until the next batch starts.
+\noindent\textbf{Loop variable capture (B023):} Python closures capture variables by reference. If \texttt{current\_depth} were referenced as a free variable inside the closure, all threads would see whatever value it holds when they \emph{execute} (the next batch's depth), not when the closure was \emph{defined}. Binding it as a keyword-only default argument (\texttt{\_d=current\_depth}) forces evaluation at definition time, making each iteration's closure hold its own snapshot.
 
-\subsubsection{Step 3b: Link-Processing Callbacks Close the UI Gap}
+\subsubsection{Step 4b: Link-Processing Callbacks Close the UI Gap}
 
-After \texttt{get\_links\_bulk} returns, the link-processing loop runs: for each of the 50 pages, it checks the visited set, stores new paths in Redis, and pushes newly discovered nodes onto the queue.  This loop is entirely Redis round-trips and can take several seconds for pages with hundreds of links.  No Wikipedia fetch is in flight during this time, so without intervention the client would stall — polling every second and seeing unchanged values.
+After \texttt{get\_links\_bulk} returns, the link-processing loop runs: for each of the 50 pages, it checks the visited set, stores new parent links in Redis, and pushes newly discovered nodes onto the queue. This loop is entirely Redis round-trips and can take several seconds for pages with hundreds of links. No Wikipedia fetch is in flight during this time, so without intervention the client would stall.
 
-To prevent this, \texttt{progress\_callback} is fired once per page \emph{after} its links have been enqueued.  At that point \texttt{queue\_size} reflects the newly added nodes, so the client sees the queue growing in real time:
+To prevent this, \texttt{progress\_callback} is fired once per page \emph{after} its links have been enqueued. At that point \texttt{queue\_size} reflects the newly added nodes:
 
-\begin{lstlisting}[caption=pathfinding.py -- Link-Processing Callbacks]
+\begin{lstlisting}[caption=pathfinding.py -- Per-page callback during link processing]
 for item in batch_items:
     current_page = item["page"]
     links = links_bulk.get(current_page, [])
-    current_path = self.cache_service.get(f"{paths_key}:{current_page}")
 
     for link in links:
         if link == end_page:
-            return {"path": current_path + [link], ...}
-        # check visited, store path, push to queue ...
+            # Store parent and reconstruct immediately
+            self.cache_service.hash_set(parent_key, link, current_page)
+            final_path = self._reconstruct_path(end_page, parent_key)
+            return {"path": final_path, "nodes_explored": nodes_explored}
 
-    # Fire after all links for this page are enqueued.
-    # queue_size now reflects the newly added nodes.
+        if not self.cache_service.set_contains(visited_key, link):
+            self.cache_service.set_add(visited_key, link)
+            self.cache_service.hash_set(parent_key, link, current_page)
+            self.queue_service.push(queue_key,
+                {"page": link, "depth": item["depth"] + 1})
+
+    # Fire after all links for this page are enqueued -- queue_size is now accurate.
     if self.progress_callback:
         self.progress_callback({
             "status": "Searching...",
@@ -685,20 +731,21 @@ for item in batch_items:
                 "last_node": current_page,
                 "queue_size": self.queue_service.length(queue_key),
             },
-            "search_time_elapsed": round(time.time() - start_time, 2),
+            "search_time_elapsed": round(time.time() - search_start_time, 2),
         })
 \end{lstlisting}
 
-\noindent\textbf{Combined update rate per batch:}
+\subsubsection{Path Reconstruction via Parent Hash}
+
+The BFS never stores explicit path lists. Instead, it records each discovered node's parent in a Redis hash:
 \begin{itemize}[leftmargin=*, nosep]
-    \item \textbf{During Wikipedia fetch:} up to 50 callbacks fired from worker threads as HTTP responses arrive via \texttt{as\_completed}.
-    \item \textbf{During link processing:} 50 callbacks fired sequentially, one per page, as its links are enqueued.
-    \item \textbf{Total:} up to 100 \texttt{update\_state} Redis writes per batch.  With the client polling every 1\,s and each batch taking 2--8\,s, the client observes meaningfully different state on every poll throughout the entire batch.
+    \item \textbf{Key:} \texttt{bfs\_parent:<uuid>} (a single Redis hash per search)
+    \item \textbf{Field:} child page title; \textbf{Value:} parent page title
 \end{itemize}
 
-\noindent\textbf{Redis cost is negligible.}  Each callback is 1 \texttt{SET} (\texttt{update\_state}) + 1 \texttt{LLEN} (\texttt{queue\_size}) = 2 ops.  100 callbacks = 200 extra ops per batch.  The link-processing loop itself already performs $\sim$60\,000 Redis ops per batch (visited checks, path stores, queue pushes).  The callbacks add $<$0.4\% overhead regardless of the number of concurrent searches.
+At the end, \texttt{\_reconstruct\_path(end\_page, parent\_key)} walks the hash backwards until it reaches \texttt{start\_page} (which has no parent entry), then reverses the list.
 
-\subsubsection{Step 4: Client Sees Progress via Polling}
+\subsubsection{Step 5: Client Sees Progress via Polling}
 
 \begin{lstlisting}[caption=Client Polling Response]
 GET /tasks/status/abc-123
@@ -712,34 +759,49 @@ GET /tasks/status/abc-123
             "nodes_explored": 42,
             "current_depth": 3,
             "last_node": "Machine learning",
-            "queue_size": 150
+            "queue_size": 150,
+            "start_page": "Python (programming language)",
+            "end_page": "Alan Turing",
+            "max_depth": 6
         },
         "search_time_elapsed": 5.2
     }
 }
 \end{lstlisting}
 
-\subsection{Architecture Diagram: Callback Flow}
+\subsection{Bidirectional BFS Progress: BidirProgressAggregator}
 
-\begin{center}
-\begin{tikzpicture}[
-    node distance=0.8cm,
-    box/.style={draw, rounded corners, minimum width=3cm, minimum height=0.8cm, align=center, font=\scriptsize},
-    arrow/.style={->, thick, >=stealth},
-    darrow/.style={->, thick, >=stealth, dashed, color=accentgreen}
-]
-    \node[box, fill=accentblue!20] (task) {Celery Task};
-    \node[box, fill=accentgreen!20, below=of task] (factory) {ServiceFactory};
-    \node[box, fill=warningorange!20, below=of factory] (pathfinder) {BFSPathFinder};
-    \node[box, fill=codegray!20, right=2.5cm of pathfinder] (redis) {Redis (Task State)};
-    \node[box, fill=accentblue!20, right=2.5cm of task] (client) {Client Polling};
-    
-    \draw[arrow] (task) -- node[left, font=\scriptsize] {creates callback} (factory);
-    \draw[arrow] (factory) -- node[left, font=\scriptsize] {injects callback} (pathfinder);
-    \draw[darrow] (pathfinder) -- node[above, font=\scriptsize] {callback writes} (redis);
-    \draw[darrow] (redis) -- node[right, font=\scriptsize] {reads state} (client);
-\end{tikzpicture}
-\end{center}
+The bidirectional pathfinder runs two concurrent frontiers. \texttt{BidirProgressAggregator} sits between them and the single progress callback:
+
+\begin{lstlisting}[caption=pathfinding.py -- BidirProgressAggregator]
+class BidirProgressAggregator:
+    def __init__(self, callback, queue_service, fwd_q, bwd_q):
+        self._callback = callback
+        self._queue_service = queue_service
+        self._fwd_q, self._bwd_q = fwd_q, bwd_q
+        self._fwd_nodes = self._bwd_nodes = 0
+        self._lock = threading.Lock()
+
+    def record(self, title: str, depth: int, direction: str) -> None:
+        with self._lock:
+            if direction == "forward":
+                self._fwd_nodes += 1
+            else:
+                self._bwd_nodes += 1
+            combined_queue = (self._queue_service.length(self._fwd_q)
+                              + self._queue_service.length(self._bwd_q))
+            self._callback({
+                "nodes_explored": self._fwd_nodes + self._bwd_nodes,
+                "queue_size": combined_queue,
+                "current_depth": depth,
+                "last_node": title,
+                "direction": direction,
+            })
+
+    @property
+    def total_nodes(self) -> int:
+        return self._fwd_nodes + self._bwd_nodes
+\end{lstlisting}
 
 \subsection{Why This Design?}
 
@@ -772,23 +834,32 @@ No Polling Inside Worker & Worker doesn't poll; it pushes. Client pulls on its o
 class ServiceFactory:
     _redis_client = None      # Singleton storage
     _cache_service = None
+    _queue_service = None
     _wikipedia_client = None
-    
+
     @classmethod
     def get_cache_service(cls):
         if cls._cache_service is None:
             redis_client = cls.get_redis_client()
-            cls._cache_service = RedisCache(redis_client)
+            cache_ttl = current_app.config.get("CACHE_TTL", 86400)
+            cls._cache_service = RedisCache(redis_client, cache_ttl)
         return cls._cache_service
-    
+
     @classmethod
-    def create_pathfinding_service(cls, algorithm="bfs", progress_callback=None):
-        # Retrieve singletons, then inject into new instance
-        wiki = cls.get_wikipedia_client()
-        cache = cls.get_cache_service()
-        queue = cls.get_queue_service()
-        
-        path_finder = RedisBasedBFSPathFinder(wiki, cache, queue, progress_callback)
+    def create_pathfinding_service(cls, algorithm="bidirectional", progress_callback=None):
+        wiki   = cls.get_wikipedia_client()
+        cache  = cls.get_cache_service()
+        queue  = cls.get_queue_service()
+        max_depth  = current_app.config.get("MAX_SEARCH_DEPTH", 6)
+        batch_size = current_app.config.get("BFS_BATCH_SIZE", 50)
+
+        if algorithm.lower() == "bidirectional":
+            path_finder = BidirectionalBFSPathFinder(
+                wiki, cache, queue, max_depth, batch_size, progress_callback)
+        else:
+            path_finder = RedisBasedBFSPathFinder(
+                wiki, cache, queue, max_depth, batch_size, progress_callback)
+
         return PathFindingService(path_finder, cache, wiki)
 \end{lstlisting}
 
@@ -812,15 +883,15 @@ To use Memcached instead of Redis:
 \toprule
 \normalfont\textbf{File} & \textbf{Purpose} \\
 \midrule
-app/core/pathfinding.py & \textbf{CORE ALGORITHM}. Redis-based BFS. Modify for algorithm changes. \\
+app/core/pathfinding.py & \textbf{CORE ALGORITHM}. \texttt{RedisBasedBFSPathFinder} (forward BFS) and \texttt{BidirectionalBFSPathFinder} (bidir BFS). Also \texttt{BidirProgressAggregator}. \\
 \addlinespace[0.3em]
-app/core/services.py & Business orchestration. Cache checking, validation, timing. \\
+app/core/services.py & Business orchestration. Cache checking, validation, timing. \texttt{PathFindingService}, \texttt{WikipediaService}, \texttt{CacheManagementService}. \\
 \addlinespace[0.3em]
 app/core/factory.py & DI container. Manages singletons and object creation. \\
 \addlinespace[0.3em]
 app/core/interfaces.py & Abstract contracts for testability and loose coupling. \\
 \addlinespace[0.3em]
-app/core/models.py & Dataclasses for requests, results, and DTOs. \\
+app/core/models.py & Dataclasses: \texttt{PathResult}, \texttt{SearchRequest}, \texttt{WikipediaPage}, \texttt{TaskStatus}, \texttt{HealthStatus}, \texttt{CacheStats}. \\
 \bottomrule
 \end{tabularx}
 
@@ -830,13 +901,13 @@ app/core/models.py & Dataclasses for requests, results, and DTOs. \\
 \toprule
 \normalfont\textbf{File} & \textbf{Purpose} \\
 \midrule
-app/infrastructure/cache.py & Redis cache implementation with connection pooling. \\
+app/infrastructure/cache.py & \texttt{RedisCache}: JSON-serialised get/set/delete, set operations (\texttt{set\_add}, \texttt{set\_contains}, \texttt{set\_contains\_many}, \texttt{set\_add\_many}), hash operations (\texttt{hash\_set}, \texttt{hash\_get}, \texttt{hash\_set\_many}), \texttt{delete\_many}, \texttt{clear\_pattern}. Pipeline used for batch ops. \\
 \addlinespace[0.3em]
-app/infrastructure/redis\_queue.py & FIFO queue for BFS state (push, pop, length). \\
+app/infrastructure/redis\_queue.py & \texttt{RedisQueue}: FIFO queue for BFS state (\texttt{push}, \texttt{pop}, \texttt{push\_batch}, \texttt{pop\_batch}, \texttt{length}, \texttt{clear}). Pipeline used for batch ops. \\
 \addlinespace[0.3em]
-app/infrastructure/tasks.py & Celery task definitions with retry logic and progress updates. \\
+app/infrastructure/tasks.py & Celery task definitions: \texttt{find\_path\_task} (main), \texttt{health\_check\_task}, \texttt{cache\_cleanup\_task}. Retry logic (\texttt{autoretry\_for} + manual retry with exponential backoff). Progress updates via \texttt{update\_state}. \\
 \addlinespace[0.3em]
-app/external/wikipedia.py & Wikipedia API client with bulk fetching and redirect handling. \\
+app/external/wikipedia.py & \texttt{WikipediaClient}: \texttt{get\_links\_bulk}, \texttt{get\_backlinks\_bulk}, \texttt{get\_page\_info}, \texttt{get\_page\_with\_redirect\_info}. Shared \texttt{\_bulk\_fetch} scaffold with cache, thread pool, \texttt{as\_completed}. Per-request rate limiting and exponential backoff. \\
 \bottomrule
 \end{tabularx}
 
@@ -849,21 +920,95 @@ app/external/wikipedia.py & Wikipedia API client with bulk fetching and redirect
 \toprule
 \normalfont\textbf{Key Pattern} & \textbf{TTL} & \textbf{Purpose} \\
 \midrule
-wiki\_links:\{page\} & 24h & Caches Wikipedia page links. High reuse. \\
-path:\{start\}:\{end\} & 1h & Caches completed path results. \\
-bfs\_visited:<uuid>:* & 1h & Temporary visited set. Cleaned after search. \\
-bfs\_paths:<uuid>:* & 1h & Temporary path tracking. Cleaned after search. \\
-bfs\_queue:<uuid> & Session & BFS queue. Explicitly deleted after search. \\
+wiki\_links:\{page\} & 24h & Caches outgoing links for a Wikipedia page (\texttt{get\_links\_bulk}). \\
+wiki\_backlinks:\{page\} & 24h & Caches backlinks (``what links here'') for a page (\texttt{get\_backlinks\_bulk}). \\
+path:\{start\}:\{end\} & 1h & Caches completed path results to avoid re-searching. \\
+page\_info:\{page\} & 2h & Caches page metadata (\texttt{WikipediaService.get\_page\_info}). \\
+bfs\_queue:\{uuid\} & Deleted & BFS frontier queue. Explicitly cleaned in \texttt{finally} block after search. \\
+bfs\_visited:\{uuid\} & Deleted & Redis set of visited page titles for the search session. \\
+bfs\_parent:\{uuid\} & Deleted & Redis hash mapping child $\rightarrow$ parent for path reconstruction. \\
+bfs\_fwd\_queue:\{sid\} & Deleted & Forward queue for bidirectional BFS. \\
+bfs\_bwd\_queue:\{sid\} & Deleted & Backward queue for bidirectional BFS. \\
+bfs\_fwd\_visited:\{sid\} & Deleted & Forward visited set for bidirectional BFS. \\
+bfs\_bwd\_visited:\{sid\} & Deleted & Backward visited set for bidirectional BFS. \\
+bfs\_fwd\_parent:\{sid\} & Deleted & Forward parent hash for bidirectional BFS. \\
+bfs\_bwd\_parent:\{sid\} & Deleted & Backward parent hash for bidirectional BFS. \\
 \bottomrule
 \end{tabularx}
 
+\begin{notebox}
+The \texttt{cache\_cleanup\_task} Celery Beat job sweeps \texttt{bfs\_*} keys hourly to clean up any orphaned search state from crashed workers. Normal search completion deletes keys immediately in a \texttt{finally} block.
+\end{notebox}
+
 % ============================================
-% SECTION 9: INTERVIEW Q&A CHEAT SHEET
+% SECTION 9: TESTING ARCHITECTURE
+% ============================================
+\section{Testing Architecture}
+
+\begin{notebox}
+All tests run with \textbf{no real Redis and no real Wikipedia API calls}. Everything external is mocked.
+\end{notebox}
+
+\subsection{Directory Structure}
+
+\begin{tabularx}{\textwidth}{@{}>{\ttfamily}l X@{}}
+\toprule
+\normalfont\textbf{File} & \textbf{What it tests} \\
+\midrule
+tests/conftest.py & Shared fixtures: app, client, all mock services. \\
+tests/unit/test\_models.py & Dataclass validation logic (\texttt{PathResult.is\_valid}, \texttt{SearchRequest.validate}). \\
+tests/unit/test\_exceptions.py & Every custom exception class and its message format. \\
+tests/unit/test\_cache\_impl.py & \texttt{RedisCache} against a mock Redis client: get/set/delete, set ops, hash ops, pipeline batching, error propagation. \\
+tests/unit/test\_redis\_queue\_impl.py & \texttt{RedisQueue} push/pop/batch/clear against mock Redis. \\
+tests/unit/test\_external\_wikipedia\_client.py & \texttt{WikipediaClient}: cache hits/misses, link filtering, redirect/disambiguation handling, backoff behaviour. \\
+tests/unit/test\_factory\_and\_tasks\_config.py & \texttt{ServiceFactory} lifecycle (create, singleton reuse, cleanup). Celery task routing config. \\
+tests/unit/test\_tasks.py & All branches of \texttt{find\_path\_task}, \texttt{health\_check\_task}, \texttt{cache\_cleanup\_task} via Celery eager execution. \\
+tests/unit/test\_middleware\_and\_logging.py & All middleware decorators (error handling, CORS, rate limiting, request size). \\
+tests/integration/test\_api\_endpoints.py & Flask routes end-to-end with mocked Celery tasks. \\
+tests/integration/test\_services.py & \texttt{PathFindingService}, \texttt{WikipediaService}, \texttt{CacheManagementService} with mocked dependencies. \\
+tests/integration/test\_pathfinding.py & BFS algorithms with stateful mock queue + cache. Also \texttt{BidirProgressAggregator}. \\
+\bottomrule
+\end{tabularx}
+
+\subsection{Mock Fixture Design}
+
+\begin{tabularx}{\textwidth}{@{}>{\ttfamily}l X@{}}
+\toprule
+\normalfont\textbf{Fixture} & \textbf{Strategy} \\
+\midrule
+mock\_redis & Raw \texttt{Mock()} with a hand-rolled \texttt{\_MockPipeline} that supports \texttt{rpush}/\texttt{lpop}/\texttt{execute} and context manager protocol. \\
+mock\_cache\_service & Stateful: backed by an in-memory \texttt{dict} (get/set), \texttt{dict[str,set]} (set ops), and \texttt{dict[str,dict]} (hash ops). Behaves identically to \texttt{RedisCache} from the caller's perspective. \\
+mock\_queue\_service & Stateful: backed by an in-memory \texttt{dict[str, list]}. Supports push/pop/push\_batch/pop\_batch/length/clear. \\
+mock\_wikipedia\_client & Simple \texttt{Mock()} with default return values. Tests override specific methods as needed. \\
+mock\_path\_finder & \texttt{Mock()} with \texttt{find\_path.return\_value = \{"path": [...], "nodes\_explored": 10\}}. \\
+mock\_celery\_task & Context manager that patches \texttt{find\_path\_task} in \texttt{routes.py} namespace. Exposes \texttt{mock\_async\_result} for state simulation. \\
+celery\_memory\_backend & Sets \texttt{task\_always\_eager=True} + \texttt{result\_backend="cache+memory://"} for task tests. Resets after test. \\
+\bottomrule
+\end{tabularx}
+
+\subsection{Testing Celery Tasks}
+
+Tasks are exercised via \texttt{task.apply(args=[...]).result} which runs them synchronously in the current process. The \texttt{celery\_memory\_backend} fixture enables \texttt{task\_always\_eager=True} so \texttt{update\_state} works without a live Redis connection.
+
+Key patterns:
+\begin{itemize}[leftmargin=*]
+    \item \textbf{Happy path:} Patch \texttt{get\_pathfinding\_service} to return a mock that returns a \texttt{PathResult}. Assert \texttt{result["status"] == "SUCCESS"}.
+    \item \textbf{Page not found:} Mock \texttt{validate\_pages} to return \texttt{(False, True, \{\})}. Assert \texttt{result["code"] == "PAGE\_NOT\_FOUND"}.
+    \item \textbf{Max retries:} Call \texttt{task.apply(args=[...], retries=3)} to set \texttt{self.request.retries == max\_retries}. Assert \texttt{result["code"] == "MAX\_RETRIES\_EXCEEDED"}.
+    \item \textbf{Progress callback:} Assert that the second argument passed to \texttt{get\_pathfinding\_service} is callable.
+\end{itemize}
+
+\subsection{Coverage}
+
+Current overall coverage: \textbf{89\%}. Key uncovered lines are in \texttt{app/\_\_init\_\_.py} (Celery integration initialisation) and some wikipedia.py pagination and error paths that require careful network simulation.
+
+% ============================================
+% SECTION 10: INTERVIEW Q&A CHEAT SHEET
 % ============================================
 \section{Interview Q\&A Cheat Sheet}
 
 \begin{qabox}{If you had to modify the core pathfinding algorithm, where would you go?}
-\textbf{Answer:} \texttt{app/core/pathfinding.py} -- specifically the \texttt{RedisBasedBFSPathFinder} class and its \texttt{find\_path()} method.
+\textbf{Answer:} \texttt{app/core/pathfinding.py} -- specifically \texttt{RedisBasedBFSPathFinder.\_perform\_bfs\_search()} for forward BFS, or \texttt{BidirectionalBFSPathFinder.\_expand\_forward\_batch()} / \texttt{\_expand\_backward\_batch()} for bidirectional BFS.
 \end{qabox}
 
 \begin{qabox}{When and where do services get initialized?}
@@ -873,20 +1018,31 @@ bfs\_queue:<uuid> & Session & BFS queue. Explicitly deleted after search. \\
 \begin{qabox}{Which objects are reused vs. created fresh?}
 \textbf{Answer:}
 \begin{itemize}[leftmargin=*, nosep]
-    \item \textbf{Reused (Singletons):} Redis Client, Wikipedia Client, Cache Service. Maintains connection pools.
-    \item \textbf{Fresh (Transient):} PathFindingService. New per task for isolated callbacks.
+    \item \textbf{Reused (Singletons):} Redis Client, Wikipedia Client, Cache Service, Queue Service. Maintains connection pools and rate-limiter state.
+    \item \textbf{Fresh (Transient):} PathFindingService and its PathFinder. New per task for isolated callbacks and algorithm selection.
 \end{itemize}
 \end{qabox}
 
 \begin{qabox}{How does the progress callback work?}
-\textbf{Answer:} 
+\textbf{Answer:}
 \begin{enumerate}[leftmargin=*, nosep]
-    \item Celery task defines a closure that calls \texttt{self.update\_state()}.
+    \item Celery task defines a closure that calls \texttt{self.update\_state(state="PROGRESS", meta=...)}.
     \item This closure is passed to \texttt{ServiceFactory.create\_pathfinding\_service()}.
-    \item Factory injects it into \texttt{RedisBasedBFSPathFinder} constructor.
-    \item BFS calls the callback every N nodes, writing progress to Redis.
-    \item Client polls \texttt{/tasks/status/<id>} to read progress.
+    \item Factory injects it into \texttt{RedisBasedBFSPathFinder} (or \texttt{BidirectionalBFSPathFinder}) constructor.
+    \item BFS defines an \texttt{on\_page\_fetched} closure that it passes to \texttt{get\_links\_bulk}.
+    \item Wikipedia client fires the closure for each page as its response arrives (via \texttt{as\_completed}) \emph{and} for cache hits.
+    \item A second callback fires after link processing per page (to report accurate queue size).
+    \item Client polls \texttt{/tasks/status/<id>} to read \texttt{state=PROGRESS} updates.
 \end{enumerate}
+\end{qabox}
+
+\begin{qabox}{Explain the two BFS algorithms and when each is used.}
+\textbf{Answer:}
+\begin{itemize}[leftmargin=*, nosep]
+    \item \textbf{bfs (RedisBasedBFSPathFinder):} Standard forward BFS. Expands from start page only, following outgoing links. Simple, predictable.
+    \item \textbf{bidirectional (BidirectionalBFSPathFinder):} Two frontiers expanding simultaneously. Forward follows outgoing links (\texttt{get\_links\_bulk}); backward follows backlinks (\texttt{get\_backlinks\_bulk} / Wikipedia's ``what links here''). Always expands the smaller frontier. Halts when a node appears in both visited sets. Path is forward\_path + backward\_chain stitched at the meeting node.
+    \item \textbf{Default:} \texttt{bidirectional}. Caller selects via the \texttt{algorithm} field in \texttt{POST /getPath}.
+\end{itemize}
 \end{qabox}
 
 \begin{qabox}{Why use Celery instead of handling pathfinding synchronously?}
@@ -904,9 +1060,9 @@ Celery enables horizontal scaling, resilience, and real-time progress.
 \begin{itemize}[leftmargin=*, nosep]
     \item Offloads memory from worker process.
     \item Enables inspection via Redis CLI.
-    \item Provides crash-recovery potential (state persists).
+    \item Provides crash-recovery potential (state persists in Redis if worker dies).
 \end{itemize}
-Trade-off: Network latency per operation (mitigated by batching).
+Trade-off: Network latency per operation (mitigated by batching with \texttt{pop\_batch}).
 \end{qabox}
 
 \begin{qabox}{How does the system scale horizontally?}
@@ -927,7 +1083,7 @@ Trade-off: Network latency per operation (mitigated by batching).
 \begin{itemize}[leftmargin=*, nosep]
     \item HTTP Keep-Alive (connection reuse).
     \item TLS session resumption (avoids 100-300ms handshake).
-    \item Cookie persistence if needed.
+    \item A shared rate-limiter lock + timestamp (ensures all threads from this process respect the rate limit globally).
 \end{itemize}
 Creating new clients per request would destroy these benefits.
 \end{qabox}
@@ -936,14 +1092,18 @@ Creating new clients per request would destroy these benefits.
 \textbf{Answer:}
 \begin{enumerate}[leftmargin=*, nosep]
     \item Create class implementing \texttt{PathFinderInterface} in \texttt{pathfinding.py}.
-    \item Add case in \texttt{ServiceFactory.create\_pathfinding\_service()}.
-    \item Update API schema to accept new algorithm name.
-    \item Add tests in \texttt{tests/integration/test\_pathfinding.py}.
+    \item Add an \texttt{elif} branch in \texttt{ServiceFactory.create\_pathfinding\_service()}.
+    \item Update \texttt{SearchRequestSchema} to accept the new algorithm name.
+    \item Add integration tests in \texttt{tests/integration/test\_pathfinding.py}.
 \end{enumerate}
 \end{qabox}
 
+\begin{qabox}{How are tests structured? What's mocked?}
+\textbf{Answer:} Tests live in \texttt{tests/unit/} (per-class) and \texttt{tests/integration/} (service interactions). No real Redis or Wikipedia calls. The \texttt{mock\_cache\_service} and \texttt{mock\_queue\_service} fixtures in \texttt{conftest.py} are \emph{stateful} in-memory mocks that behave identically to the real implementations. Celery tasks are tested via \texttt{task.apply()} in eager mode with an in-memory result backend.
+\end{qabox}
+
 % ============================================
-% SECTION 10: QUICK REFERENCE
+% SECTION 11: QUICK REFERENCE
 % ============================================
 \section{Quick Reference: Where to Make Changes}
 
@@ -951,19 +1111,21 @@ Creating new clients per request would destroy these benefits.
 \toprule
 Goal & Location \\
 \midrule
-Modify BFS algorithm & \texttt{app/core/pathfinding.py} \\
-Add new API endpoint & \texttt{app/api/routes.py} \\
+Modify forward BFS & \texttt{app/core/pathfinding.py} -- \texttt{RedisBasedBFSPathFinder} \\
+Modify bidirectional BFS & \texttt{app/core/pathfinding.py} -- \texttt{BidirectionalBFSPathFinder} \\
+Add new API endpoint & \texttt{app/api/routes.py} (add route + Flasgger YAML docstring) \\
 Change request validation & \texttt{app/api/schemas.py} \\
 Add new Celery task & \texttt{app/infrastructure/tasks.py} \\
-Swap cache implementation & Implement interface, update \texttt{factory.py} \\
+Swap cache implementation & Implement \texttt{CacheServiceInterface}, update \texttt{factory.py} \\
 Add new exception type & \texttt{app/utils/exceptions.py} \\
 Change configuration & \texttt{config/base.py} \\
 Modify Wikipedia API logic & \texttt{app/external/wikipedia.py} \\
+Add tests & \texttt{tests/unit/} for isolated class tests, \texttt{tests/integration/} for service interactions \\
 \bottomrule
 \end{tabularx}
 
 % ============================================
-% SECTION 11: API ENDPOINTS
+% SECTION 12: API ENDPOINTS
 % ============================================
 \section{API Endpoints Reference}
 
@@ -971,18 +1133,27 @@ Modify Wikipedia API logic & \texttt{app/external/wikipedia.py} \\
 \toprule
 \textbf{Method} & \normalfont\textbf{Endpoint} & \textbf{Description} \\
 \midrule
-POST & /getPath & Start pathfinding. Returns task ID. \\
-GET & /tasks/status/<id> & Poll for task status and progress. \\
-POST & /explore & Explore links from a page. \\
-GET & /health & System health check. \\
-GET & /api & API information. \\
-POST & /cache/clear & Admin: clear cache by pattern. \\
-GET & /api/docs & Swagger UI (interactive API documentation). \\
+POST   & /getPath & Start pathfinding. Returns task ID + poll URL (202 Accepted). \\
+GET    & /tasks/status/<id> & Poll for task status: PENDING, IN\_PROGRESS (PROGRESS state), SUCCESS, FAILURE, RETRY. \\
+GET    & /tasks & List all active, reserved, and scheduled Celery tasks across workers. Returns counts and raw task metadata. 503 if no workers reachable. \\
+DELETE & /tasks/<id> & Revoke (cancel) a specific task. Sends SIGTERM if already running (\texttt{?terminate=false} to skip). Returns 404 if task already in SUCCESS/FAILURE. \\
+DELETE & /tasks & Revoke all active and reserved tasks across all workers. Accepts same \texttt{?terminate} query param. \\
+GET    & /health & System health check: Redis ping, cache round-trip, Wikipedia client init. \\
+GET    & / & Serve static web UI (\texttt{static/index.html}). All non-API paths redirect here. \\
+GET    & /api & API metadata and endpoint list. \\
+GET    & /api/docs & Swagger UI (auto-assembled from YAML docstrings via Flasgger). \\
+POST   & /cache/clear & Admin: clear Redis cache by key pattern (default: \texttt{wiki\_links:*}). \\
 \bottomrule
 \end{tabularx}
 
+\begin{notebox}
+The \texttt{catch\_all} route (\texttt{/<path:path>}) redirects all unrecognised paths to \texttt{/}. Paths starting with \texttt{getPath}, \texttt{tasks}, \texttt{health}, \texttt{cache}, or \texttt{api} return a structured JSON 404 instead.
+
+Task management endpoints use \texttt{celery.control.inspect(timeout=2.0)} for listing and \texttt{celery.control.revoke()} for cancellation. The inspect call broadcasts to all workers and aggregates responses; a 2-second timeout avoids hanging the HTTP request when workers are unavailable.
+\end{notebox}
+
 % ============================================
-% SECTION 12: CONFIGURATION
+% SECTION 13: CONFIGURATION
 % ============================================
 \section{Configuration Reference}
 
@@ -990,13 +1161,17 @@ GET & /api/docs & Swagger UI (interactive API documentation). \\
 \toprule
 \normalfont\textbf{Variable} & \textbf{Default} & \textbf{Description} \\
 \midrule
-REDIS\_URL & localhost:6379 & Redis connection URL. \\
-MAX\_SEARCH\_DEPTH & 6 & Maximum BFS depth. \\
-BFS\_BATCH\_SIZE & 50 & Pages per batch in BFS. \\
-CACHE\_TTL & 86400 & Default cache TTL (24h). \\
-WIKIPEDIA\_MAX\_WORKERS & 10 & Thread pool for Wikipedia API. \\
-CELERY\_TASK\_SOFT\_TIME\_LIMIT & 300 & Soft timeout (5m). \\
-CELERY\_TASK\_TIME\_LIMIT & 600 & Hard timeout (10m). \\
+REDIS\_URL & redis://localhost:6379/0 & Redis connection URL. \\
+MAX\_SEARCH\_DEPTH & 6 & Maximum BFS depth before giving up. \\
+BFS\_BATCH\_SIZE & 50 & Pages per batch popped from queue. \\
+CACHE\_TTL & 86400 & Default cache TTL for wiki\_links (24h). \\
+WIKIPEDIA\_MAX\_WORKERS & 10 & Thread pool size for parallel Wikipedia API calls. \\
+WIKIPEDIA\_MAX\_PAGINATE\_CALLS & 3 & Pagination calls per page (3 $\times$ 500 = 1500 links max). \\
+WIKIPEDIA\_REQUEST\_DELAY & 0.1 & Minimum seconds between Wikipedia requests (rate limit). \\
+WIKIPEDIA\_BACKOFF\_MAX\_RETRIES & 5 & Max retry attempts with exponential backoff. \\
+CELERY\_TASK\_SOFT\_TIME\_LIMIT & 300 & Soft timeout for pathfinding task (5 min). \\
+CELERY\_TASK\_TIME\_LIMIT & 600 & Hard timeout for pathfinding task (10 min). \\
+LOG\_LEVEL & INFO & Logging level. \\
 \bottomrule
 \end{tabularx}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ Jinja2==3.1.6
 kombu==5.5.4
 MarkupSafe==3.0.2
 marshmallow==3.22.0
-networkx==3.4.2
 packaging==25.0
 pluggy==1.6.0
 prompt_toolkit==3.0.51

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,17 @@ def mock_redis():
 
 
 @pytest.fixture(scope="function")
+def mock_path_finder():
+    """Mock PathFinderInterface for testing."""
+    mock = Mock()
+    mock.find_path.return_value = {
+        "path": ["Page A", "Page B", "Page C"],
+        "nodes_explored": 10,
+    }
+    return mock
+
+
+@pytest.fixture(scope="function")
 def mock_wikipedia_client():
     """Mock Wikipedia client for testing."""
     mock_client = Mock()
@@ -251,21 +262,6 @@ def sample_path_data():
 
 
 @pytest.fixture(scope="function")
-def sample_explore_data():
-    """Sample explore data for testing."""
-    return {
-        "start_page": "Test Page",
-        "nodes": ["Test Page", "Link 1", "Link 2", "Link 3"],
-        "edges": [
-            ("Test Page", "Link 1"),
-            ("Test Page", "Link 2"),
-            ("Test Page", "Link 3"),
-        ],
-        "total_links": 3,
-    }
-
-
-@pytest.fixture(scope="function")
 def valid_search_request():
     """Valid search request data."""
     return {
@@ -273,12 +269,6 @@ def valid_search_request():
         "end": "Machine learning",
         "algorithm": "bfs",
     }
-
-
-@pytest.fixture(scope="function")
-def valid_explore_request():
-    """Valid explore request data."""
-    return {"start": "Python (programming language)", "max_links": 10}
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -101,76 +101,51 @@ class TestPathfindingAPI:
         assert data["task_id"] == task_id
         assert "error" in data
 
+    def test_get_task_status_in_progress(self, client, mock_celery_task):
+        """PROGRESS state maps to status IN_PROGRESS with progress payload."""
+        task_id = "test-task-id-123"
 
-class TestExploreAPI:
-    """Integration tests for explore API endpoints."""
+        mock_async_result = mock_celery_task.mock_async_result
+        mock_async_result.state = "PROGRESS"
+        mock_async_result.info = {
+            "status": "Searching...",
+            "search_stats": {
+                "nodes_explored": 42,
+                "current_depth": 3,
+                "last_node": "Some Page",
+                "queue_size": 15,
+            },
+            "search_time_elapsed": 2.5,
+        }
 
-    @patch("app.core.factory.ServiceFactory.create_explore_service")
-    def test_explore_valid_request(
-        self, mock_service_factory, client, valid_explore_request, sample_explore_data
-    ):
-        """Test successful explore request."""
-        # Mock explore service
-        from app.core.models import ExploreResult
-
-        mock_explore_service = Mock()
-        mock_explore_result = ExploreResult(**sample_explore_data)
-        mock_explore_service.explore_page.return_value = mock_explore_result
-        mock_service_factory.return_value = mock_explore_service
-
-        response = client.post(
-            "/explore",
-            data=json.dumps(valid_explore_request),
-            content_type="application/json",
-        )
+        response = client.get(f"/tasks/status/{task_id}")
 
         assert response.status_code == 200
         data = json.loads(response.data)
-        assert data["start_page"] == sample_explore_data["start_page"]
-        assert data["nodes"] == sample_explore_data["nodes"]
-        # Edges are serialized as lists, not tuples, in JSON
-        expected_edges = [list(edge) for edge in sample_explore_data["edges"]]
-        assert data["edges"] == expected_edges
+        assert data["status"] == "IN_PROGRESS"
+        assert data["task_id"] == task_id
+        assert "progress" in data
 
-    def test_explore_invalid_request(self, client):
-        """Test explore request with invalid data."""
-        invalid_request = {"start": ""}  # Empty start page
+    def test_get_task_status_retry(self, client, mock_celery_task):
+        """RETRY (and other non-standard states) are returned as-is from the else branch."""
+        task_id = "test-task-id-123"
 
-        response = client.post(
-            "/explore",
-            data=json.dumps(invalid_request),
-            content_type="application/json",
-        )
+        mock_async_result = mock_celery_task.mock_async_result
+        mock_async_result.state = "RETRY"
+        mock_async_result.info = {
+            "error": "Connection failed",
+            "retry_count": 1,
+            "max_retries": 3,
+        }
 
-        assert response.status_code == 400
+        response = client.get(f"/tasks/status/{task_id}")
+
+        assert response.status_code == 200
         data = json.loads(response.data)
-        assert data["error"] is True
-        assert data["code"] == "VALIDATION_ERROR"
-
-    @patch("app.core.factory.ServiceFactory.create_explore_service")
-    def test_explore_page_not_found(
-        self, mock_service_factory, client, valid_explore_request
-    ):
-        """Test explore request for non-existent page."""
-        from app.utils.exceptions import InvalidPageError
-
-        # Mock explore service to raise exception
-        mock_explore_service = Mock()
-        mock_explore_service.explore_page.side_effect = InvalidPageError(
-            "Page 'NonExistent' does not exist"
-        )
-        mock_service_factory.return_value = mock_explore_service
-
-        response = client.post(
-            "/explore",
-            data=json.dumps(valid_explore_request),
-            content_type="application/json",
-        )
-
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["error"] is True
-        assert data["code"] == "INVALID_PAGE"
+        assert data["task_id"] == task_id
+        # Falls through to the else branch — status reflects the raw Celery state
+        assert data["status"] == "RETRY"
+        assert "info" in data
 
 
 class TestHealthCheckAPI:

--- a/tests/integration/test_pathfinding.py
+++ b/tests/integration/test_pathfinding.py
@@ -2,7 +2,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from app.core.pathfinding import BidirectionalBFSPathFinder, RedisBasedBFSPathFinder
+from app.core.pathfinding import (
+    BidirectionalBFSPathFinder,
+    BidirProgressAggregator,
+    RedisBasedBFSPathFinder,
+)
 from app.utils.exceptions import InvalidPageError, PathNotFoundError
 
 
@@ -88,42 +92,6 @@ class TestRedisBasedBFSPathFinder:
         with pytest.raises(InvalidPageError):
             pathfinder.find_path("Page A", "")
 
-    def test_find_path_nonexistent_start_page(
-        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
-    ):
-        """Test pathfinding when start page doesn't exist."""
-        # Mock start page doesn't exist
-        mock_wikipedia_client.page_exists.side_effect = lambda page: (
-            page != "NonExistent"
-        )
-
-        pathfinder = RedisBasedBFSPathFinder(
-            mock_wikipedia_client, mock_cache_service, mock_queue_service
-        )
-
-        with pytest.raises(
-            InvalidPageError, match="Start page 'NonExistent' does not exist"
-        ):
-            pathfinder.find_path("NonExistent", "Page B")
-
-    def test_find_path_nonexistent_end_page(
-        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
-    ):
-        """Test pathfinding when end page doesn't exist."""
-        # Mock end page doesn't exist
-        mock_wikipedia_client.page_exists.side_effect = lambda page: (
-            page != "NonExistent"
-        )
-
-        pathfinder = RedisBasedBFSPathFinder(
-            mock_wikipedia_client, mock_cache_service, mock_queue_service
-        )
-
-        with pytest.raises(
-            InvalidPageError, match="End page 'NonExistent' does not exist"
-        ):
-            pathfinder.find_path("Page A", "NonExistent")
-
     def test_find_path_no_path_exists(
         self, mock_wikipedia_client, mock_cache_service, mock_queue_service
     ):
@@ -177,48 +145,10 @@ class TestRedisBasedBFSPathFinder:
         with pytest.raises(PathNotFoundError):
             pathfinder.find_path("Page A", "Page B")
 
-    def test_redis_queue_integration(self, mock_wikipedia_client, mock_cache_service):
-        """Test that Redis queue operations work correctly."""
-        # Use a real-like queue implementation for testing
-        queue_data = {}
-
-        def mock_push(queue_name, item):
-            if queue_name not in queue_data:
-                queue_data[queue_name] = []
-            queue_data[queue_name].append(item)
-
-        def mock_pop(queue_name):
-            if queue_name in queue_data and queue_data[queue_name]:
-                return queue_data[queue_name].pop(0)
-            return None
-
-        def mock_length(queue_name):
-            return len(queue_data.get(queue_name, []))
-
-        def mock_clear(queue_name):
-            queue_data.pop(queue_name, None)
-
-        def mock_push_batch(queue_name, items):
-            if queue_name not in queue_data:
-                queue_data[queue_name] = []
-            queue_data[queue_name].extend(items)
-
-        def mock_pop_batch(queue_name, count):
-            if queue_name not in queue_data:
-                return []
-            batch = queue_data[queue_name][:count]
-            queue_data[queue_name] = queue_data[queue_name][count:]
-            return batch
-
-        mock_queue_service = Mock()
-        mock_queue_service.push.side_effect = mock_push
-        mock_queue_service.pop.side_effect = mock_pop
-        mock_queue_service.length.side_effect = mock_length
-        mock_queue_service.clear.side_effect = mock_clear
-        mock_queue_service.push_batch.side_effect = mock_push_batch
-        mock_queue_service.pop_batch.side_effect = mock_pop_batch
-
-        # Mock simple path A -> B
+    def test_redis_queue_integration(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """Queue push and pop_batch are called during BFS (uses conftest fixture)."""
         mock_wikipedia_client.page_exists.return_value = True
         mock_wikipedia_client.get_links_bulk.return_value = {"Page A": ["Page B"]}
 
@@ -230,7 +160,6 @@ class TestRedisBasedBFSPathFinder:
 
         assert result["path"] == ["Page A", "Page B"]
         assert "nodes_explored" in result
-        # Verify queue operations were called
         assert mock_queue_service.push.called
         assert mock_queue_service.pop_batch.called
 
@@ -252,6 +181,121 @@ class TestRedisBasedBFSPathFinder:
         # Verify set/hash interface methods were used for visited tracking
         assert mock_cache_service.set_add.called
         assert mock_cache_service.hash_set.called
+
+
+class TestProgressCallback:
+    """Tests for progress callback invocation in RedisBasedBFSPathFinder."""
+
+    def test_callback_fires_during_multi_hop_search(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """Progress callback fires at least once during a non-trivial search."""
+        progress_calls = []
+
+        def mock_get_links(pages, on_page_fetched=None):
+            mapping = {
+                "Page A": ["Page X"],  # first batch: no direct path
+                "Page X": ["Page B"],  # second batch: finds target
+            }
+            # Simulate Wikipedia client calling the per-page callback
+            if on_page_fetched:
+                for page in pages:
+                    on_page_fetched(page, mapping.get(page, []))
+            return {page: mapping.get(page, []) for page in pages}
+
+        mock_wikipedia_client.get_links_bulk.side_effect = mock_get_links
+
+        pathfinder = RedisBasedBFSPathFinder(
+            mock_wikipedia_client,
+            mock_cache_service,
+            mock_queue_service,
+            progress_callback=lambda data: progress_calls.append(data),
+        )
+
+        result = pathfinder.find_path("Page A", "Page B")
+
+        assert result["path"] == ["Page A", "Page X", "Page B"]
+        assert len(progress_calls) > 0
+        for call in progress_calls:
+            assert "search_stats" in call
+            assert "nodes_explored" in call["search_stats"]
+
+    def test_no_callback_does_not_raise(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """Pathfinder with no callback runs without error."""
+        mock_wikipedia_client.get_links_bulk.return_value = {"Page A": ["Page B"]}
+
+        pathfinder = RedisBasedBFSPathFinder(
+            mock_wikipedia_client,
+            mock_cache_service,
+            mock_queue_service,
+            progress_callback=None,
+        )
+
+        result = pathfinder.find_path("Page A", "Page B")
+        assert result["path"] == ["Page A", "Page B"]
+
+
+class TestBidirProgressAggregator:
+    """Unit tests for BidirProgressAggregator."""
+
+    def _make_agg(self, callback=None):
+        queue_svc = Mock()
+        queue_svc.length.return_value = 0
+        return BidirProgressAggregator(callback or Mock(), queue_svc, "fwd_q", "bwd_q")
+
+    def test_forward_and_backward_counting(self):
+        agg = self._make_agg()
+        agg.record("A", 0, "forward")
+        agg.record("B", 1, "backward")
+        agg.record("C", 1, "forward")
+
+        assert agg.total_nodes == 3
+        assert agg._fwd_nodes == 2
+        assert agg._bwd_nodes == 1
+
+    def test_total_nodes_starts_at_zero(self):
+        agg = self._make_agg()
+        assert agg.total_nodes == 0
+
+    def test_callback_receives_combined_queue_size(self):
+        received = []
+        queue_svc = Mock()
+        queue_svc.length.side_effect = lambda q: 3 if q == "fwd_q" else 2
+
+        agg = BidirProgressAggregator(received.append, queue_svc, "fwd_q", "bwd_q")
+        agg.record("Page A", 0, "forward")
+
+        assert len(received) == 1
+        update = received[0]
+        assert update["nodes_explored"] == 1
+        assert update["queue_size"] == 5  # 3 + 2
+        assert update["direction"] == "forward"
+        assert update["last_node"] == "Page A"
+        assert update["current_depth"] == 0
+
+    def test_backward_direction_tracked_separately(self):
+        received = []
+        queue_svc = Mock()
+        queue_svc.length.return_value = 0
+
+        agg = BidirProgressAggregator(received.append, queue_svc, "fwd_q", "bwd_q")
+        agg.record("End", 0, "backward")
+
+        assert received[0]["direction"] == "backward"
+        assert agg._bwd_nodes == 1
+        assert agg._fwd_nodes == 0
+
+    def test_callback_called_once_per_record(self):
+        callback = Mock()
+        agg = self._make_agg(callback)
+
+        for i in range(5):
+            agg.record(f"Page {i}", i, "forward")
+
+        assert callback.call_count == 5
+        assert agg.total_nodes == 5
 
 
 class TestBidirectionalBFSPathFinder:
@@ -289,16 +333,74 @@ class TestBidirectionalBFSPathFinder:
         assert result["path"] == ["Page A"]
         assert result["nodes_explored"] == 1
 
+    def test_bidirectional_invalid_empty_pages(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """Empty page names raise InvalidPageError."""
+        pathfinder = BidirectionalBFSPathFinder(
+            mock_wikipedia_client, mock_cache_service, mock_queue_service
+        )
+
+        with pytest.raises(InvalidPageError):
+            pathfinder.find_path("", "Page B")
+
+        with pytest.raises(InvalidPageError):
+            pathfinder.find_path("Page A", "")
+
+    def test_bidirectional_no_path_found(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """PathNotFoundError is raised when frontiers cannot meet."""
+
+        def isolated_links(pages, on_page_fetched=None):
+            return {page: [] for page in pages}
+
+        mock_wikipedia_client.get_links_bulk.side_effect = isolated_links
+        mock_wikipedia_client.get_backlinks_bulk.side_effect = isolated_links
+
+        pathfinder = BidirectionalBFSPathFinder(
+            mock_wikipedia_client, mock_cache_service, mock_queue_service, max_depth=2
+        )
+
+        with pytest.raises(PathNotFoundError):
+            pathfinder.find_path("Page A", "Page B")
+
+    def test_bidirectional_progress_callback(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """Progress callback fires when provided to BidirectionalBFSPathFinder."""
+        progress_calls = []
+
+        def fwd_links(pages, on_page_fetched=None):
+            mapping = {"Page A": ["Page B"]}
+            if on_page_fetched:
+                for p in pages:
+                    on_page_fetched(p, mapping.get(p, []))
+            return {p: mapping.get(p, []) for p in pages}
+
+        mock_wikipedia_client.get_links_bulk.side_effect = fwd_links
+        mock_wikipedia_client.get_backlinks_bulk.return_value = {}
+
+        pathfinder = BidirectionalBFSPathFinder(
+            mock_wikipedia_client,
+            mock_cache_service,
+            mock_queue_service,
+            progress_callback=lambda d: progress_calls.append(d),
+        )
+
+        pathfinder.find_path("Page A", "Page B")
+        assert len(progress_calls) > 0
+
 
 class TestPathfindingErrorHandling:
     """Integration tests for pathfinding error scenarios."""
 
-    def test_wikipedia_api_error_handling(self, mock_cache_service, mock_queue_service):
-        """Test handling of Wikipedia API errors."""
+    def test_wikipedia_api_error_handling(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """WikipediaAPIError from get_links_bulk propagates out of find_path."""
         from app.utils.exceptions import WikipediaAPIError
 
-        # Mock Wikipedia client to raise API error
-        mock_wikipedia_client = Mock()
         mock_wikipedia_client.page_exists.return_value = True
         mock_wikipedia_client.get_links_bulk.side_effect = WikipediaAPIError(
             "API request failed"
@@ -311,20 +413,16 @@ class TestPathfindingErrorHandling:
         with pytest.raises(WikipediaAPIError):
             pathfinder.find_path("Page A", "Page B")
 
-    def test_cache_error_handling(self, mock_wikipedia_client, mock_queue_service):
-        """Test handling of cache errors during BFS state operations."""
+    def test_cache_error_handling(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """CacheConnectionError from set_add propagates out of find_path."""
         from app.utils.exceptions import CacheConnectionError
 
-        mock_cache_service = Mock()
-        mock_cache_service.set_add.side_effect = CacheConnectionError("Redis connection failed")
-        mock_cache_service.set_contains.return_value = False
-        mock_cache_service.delete_many.return_value = None
-
         mock_wikipedia_client.page_exists.return_value = True
-        # Links that don't immediately lead to target, forcing set_add call
-        mock_wikipedia_client.get_links_bulk.return_value = {
-            "Page A": ["Page C", "Page D"]
-        }
+        mock_cache_service.set_add.side_effect = CacheConnectionError(
+            "Redis connection failed"
+        )
 
         pathfinder = RedisBasedBFSPathFinder(
             mock_wikipedia_client, mock_cache_service, mock_queue_service
@@ -333,17 +431,16 @@ class TestPathfindingErrorHandling:
         with pytest.raises(CacheConnectionError):
             pathfinder.find_path("Page A", "Page B")
 
-    def test_queue_error_handling(self, mock_wikipedia_client, mock_cache_service):
-        """Test handling of queue errors."""
+    def test_queue_error_handling(
+        self, mock_wikipedia_client, mock_cache_service, mock_queue_service
+    ):
+        """CacheConnectionError from queue.push propagates out of find_path."""
         from app.utils.exceptions import CacheConnectionError
 
-        # Mock queue service to raise error
-        mock_queue_service = Mock()
+        mock_wikipedia_client.page_exists.return_value = True
         mock_queue_service.push.side_effect = CacheConnectionError(
             "Queue operation failed"
         )
-
-        mock_wikipedia_client.page_exists.return_value = True
 
         pathfinder = RedisBasedBFSPathFinder(
             mock_wikipedia_client, mock_cache_service, mock_queue_service

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,11 +1,10 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
-from app.core.models import ExploreRequest, ExploreResult, PathResult, SearchRequest
+from app.core.models import PathResult, SearchRequest
 from app.core.services import (
     CacheManagementService,
-    ExploreService,
     PathFindingService,
     WikipediaService,
 )
@@ -19,27 +18,16 @@ from app.utils.exceptions import (
 class TestPathFindingService:
     """Integration tests for PathFindingService."""
 
-    def test_find_path_success(self, mock_wikipedia_client, mock_cache_service):
-        """Test successful pathfinding."""
-        # Mock path finder
-        mock_path_finder = Mock()
-        mock_path_finder.find_path.return_value = {
-            "path": ["Page A", "Page B", "Page C"],
-            "nodes_explored": 10,
-        }
-
-        # Create service
+    def test_find_path_success(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
         service = PathFindingService(
             mock_path_finder, mock_cache_service, mock_wikipedia_client
         )
-
-        # Create request
         request = SearchRequest(start_page="Page A", end_page="Page C")
 
-        # Execute
         result = service.find_path(request)
 
-        # Assert
         assert isinstance(result, PathResult)
         assert result.path == ["Page A", "Page B", "Page C"]
         assert result.length == 3
@@ -47,9 +35,10 @@ class TestPathFindingService:
         assert result.end_page == "Page C"
         assert result.search_time is not None
 
-    def test_find_path_cached_result(self, mock_wikipedia_client, mock_cache_service):
-        """Test pathfinding with cached result."""
-        # Mock cached result
+    def test_find_path_cached_result(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """When a cached result exists, the path finder is not invoked."""
         cached_data = {
             "path": ["Page A", "Page B", "Page C"],
             "length": 3,
@@ -58,84 +47,78 @@ class TestPathFindingService:
             "search_time": 1.5,
             "nodes_explored": 10,
         }
-        # Set the cache key that will be used
         cache_key = "path:Page A:Page C"
         mock_cache_service.get.side_effect = lambda key: (
             cached_data if key == cache_key else None
         )
 
-        # Mock path finder (should not be called)
-        mock_path_finder = Mock()
-
-        # Create service
         service = PathFindingService(
             mock_path_finder, mock_cache_service, mock_wikipedia_client
         )
+        result = service.find_path(
+            SearchRequest(start_page="Page A", end_page="Page C")
+        )
 
-        # Create request
-        request = SearchRequest(start_page="Page A", end_page="Page C")
-
-        # Execute
-        result = service.find_path(request)
-
-        # Assert
         assert isinstance(result, PathResult)
         assert result.path == cached_data["path"]
         mock_path_finder.find_path.assert_not_called()
 
-    def test_find_path_invalid_request(self, mock_wikipedia_client, mock_cache_service):
-        """Test pathfinding with invalid request."""
-        mock_path_finder = Mock()
+    def test_find_path_result_is_cached(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """A successful find_path result is written to the cache."""
         service = PathFindingService(
             mock_path_finder, mock_cache_service, mock_wikipedia_client
         )
+        service.find_path(SearchRequest(start_page="Page A", end_page="Page C"))
 
-        # Invalid request (empty start page)
+        mock_cache_service.set.assert_called_once()
+        call_key = mock_cache_service.set.call_args[0][0]
+        assert call_key == "path:Page A:Page C"
+
+    def test_find_path_invalid_request(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """Invalid SearchRequest raises InvalidPageError before path_finder is called."""
+        service = PathFindingService(
+            mock_path_finder, mock_cache_service, mock_wikipedia_client
+        )
         request = SearchRequest(start_page="", end_page="Page C")
 
         with pytest.raises(InvalidPageError):
             service.find_path(request)
 
-    def test_find_path_not_found(self, mock_wikipedia_client, mock_cache_service):
-        """Test pathfinding when no path exists."""
-        # Mock path finder to raise PathNotFoundError
-        mock_path_finder = Mock()
-        mock_path_finder.find_path.side_effect = PathNotFoundError("Page A", "Page C")
+        mock_path_finder.find_path.assert_not_called()
 
+    def test_find_path_not_found(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """PathNotFoundError from the path finder propagates unchanged."""
+        mock_path_finder.find_path.side_effect = PathNotFoundError("Page A", "Page C")
         service = PathFindingService(
             mock_path_finder, mock_cache_service, mock_wikipedia_client
         )
 
-        request = SearchRequest(start_page="Page A", end_page="Page C")
-
         with pytest.raises(PathNotFoundError):
-            service.find_path(request)
+            service.find_path(SearchRequest(start_page="Page A", end_page="Page C"))
 
-    def test_validate_pages(self, mock_wikipedia_client, mock_cache_service):
-        """Test page validation."""
+    def test_validate_pages(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """Both pages existing → (True, True, details); missing end → (True, False, ...)."""
 
-        # Mock Wikipedia client responses
         def mock_get_page_info(page):
-            if page == "NonExistent":
-                return {
-                    "exists": False,
-                    "final_title": page,
-                    "was_redirected": False,
-                    "is_disambiguation": False,
-                }
-            else:
-                return {
-                    "exists": True,
-                    "final_title": page,
-                    "was_redirected": False,
-                    "is_disambiguation": False,
-                }
+            return {
+                "exists": page != "NonExistent",
+                "final_title": page,
+                "was_redirected": False,
+                "is_disambiguation": False,
+            }
 
         mock_wikipedia_client.get_page_with_redirect_info.side_effect = (
             mock_get_page_info
         )
 
-        mock_path_finder = Mock()
         service = PathFindingService(
             mock_path_finder, mock_cache_service, mock_wikipedia_client
         )
@@ -157,103 +140,6 @@ class TestPathFindingService:
         assert end_exists is False
         assert validation_details["start_page"]["exists"] is True
         assert validation_details["end_page"]["exists"] is False
-
-
-class TestExploreService:
-    """Integration tests for ExploreService."""
-
-    def test_explore_page_success(self, mock_wikipedia_client, mock_cache_service):
-        """Test successful page exploration."""
-        # Mock Wikipedia client
-        mock_wikipedia_client.page_exists.return_value = True
-        mock_wikipedia_client.get_links_bulk.return_value = {
-            "Test Page": ["Link 1", "Link 2", "Link 3", "Link 4", "Link 5"]
-        }
-
-        # Create service
-        service = ExploreService(mock_wikipedia_client, mock_cache_service)
-
-        # Create request
-        request = ExploreRequest(start_page="Test Page", max_links=3)
-
-        # Execute
-        result = service.explore_page(request)
-
-        # Assert
-        assert isinstance(result, ExploreResult)
-        assert result.start_page == "Test Page"
-        assert len(result.nodes) == 4  # Start page + 3 links
-        assert len(result.edges) == 3  # 3 connections
-        assert result.total_links == 5  # Total available links
-
-    def test_explore_page_cached_result(
-        self, mock_wikipedia_client, mock_cache_service
-    ):
-        """Test page exploration with cached result."""
-        # Mock cached result
-        cached_data = {
-            "start_page": "Test Page",
-            "nodes": ["Test Page", "Link 1", "Link 2"],
-            "edges": [("Test Page", "Link 1"), ("Test Page", "Link 2")],
-            "total_links": 2,
-        }
-        # The cache key includes max_links (which defaults to None now)
-        cache_key = "explore:Test Page:None"
-        mock_cache_service.get.side_effect = lambda key: (
-            cached_data if key == cache_key else None
-        )
-
-        # Create service
-        service = ExploreService(mock_wikipedia_client, mock_cache_service)
-
-        # Create request
-        request = ExploreRequest(start_page="Test Page")
-
-        # Execute
-        result = service.explore_page(request)
-
-        # Assert
-        assert isinstance(result, ExploreResult)
-        assert result.start_page == cached_data["start_page"]
-        mock_wikipedia_client.get_links_bulk.assert_not_called()
-
-    def test_explore_page_not_found(self, mock_wikipedia_client, mock_cache_service):
-        """Test exploration of non-existent page."""
-        # Mock page doesn't exist
-        mock_wikipedia_client.page_exists.return_value = False
-
-        service = ExploreService(mock_wikipedia_client, mock_cache_service)
-        request = ExploreRequest(start_page="NonExistent")
-
-        with pytest.raises(InvalidPageError):
-            service.explore_page(request)
-
-    def test_explore_page_no_links(self, mock_wikipedia_client, mock_cache_service):
-        """Test exploration of page with no links."""
-        # Mock page exists but has no links
-        mock_wikipedia_client.page_exists.return_value = True
-        mock_wikipedia_client.get_links_bulk.return_value = {"Test Page": []}
-
-        service = ExploreService(mock_wikipedia_client, mock_cache_service)
-        request = ExploreRequest(start_page="Test Page")
-
-        result = service.explore_page(request)
-
-        assert isinstance(result, ExploreResult)
-        assert result.start_page == "Test Page"
-        assert result.nodes == ["Test Page"]
-        assert result.edges == []
-        assert result.total_links == 0
-
-    def test_explore_invalid_request(self, mock_wikipedia_client, mock_cache_service):
-        """Test exploration with invalid request."""
-        service = ExploreService(mock_wikipedia_client, mock_cache_service)
-
-        # Invalid request (empty start page)
-        request = ExploreRequest(start_page="")
-
-        with pytest.raises(InvalidPageError):
-            service.explore_page(request)
 
 
 class TestWikipediaService:
@@ -322,77 +208,12 @@ class TestWikipediaService:
         with pytest.raises(InvalidPageError):
             service.get_page_info("")  # Empty title
 
-    def test_search_pages(self, mock_wikipedia_client, mock_cache_service):
-        """Test page search functionality."""
-        service = WikipediaService(mock_wikipedia_client, mock_cache_service)
-
-        # Current implementation returns empty list
-        result = service.search_pages("python programming")
-        assert result == []
-
-
-class TestServiceIntegration:
-    """Integration tests combining multiple services."""
-
-    @patch("app.core.factory.ServiceFactory")
-    def test_pathfinding_with_explore_validation(
-        self,
-        mock_factory,
-        mock_wikipedia_client,
-        mock_cache_service,
-        mock_queue_service,
-    ):
-        """Test pathfinding after validating pages exist through explore."""
-        # Setup mocks
-        mock_path_finder = Mock()
-        mock_path_finder.find_path.return_value = {
-            "path": ["Page A", "Page B", "Page C"],
-            "nodes_explored": 10,
-        }
-
-        # Mock page exists and has links
-        mock_wikipedia_client.page_exists.return_value = True
-        mock_wikipedia_client.get_links_bulk.return_value = {
-            "Page A": ["Page B", "Page C"]
-        }
-
-        # Create services
-        path_service = PathFindingService(
-            mock_path_finder, mock_cache_service, mock_wikipedia_client
-        )
-        explore_service = ExploreService(mock_wikipedia_client, mock_cache_service)
-
-        # First, explore the starting page to validate it exists
-        explore_request = ExploreRequest(start_page="Page A", max_links=5)
-        explore_result = explore_service.explore_page(explore_request)
-
-        assert explore_result.start_page == "Page A"
-        assert len(explore_result.nodes) > 1  # Has links
-
-        # Then find path
-        search_request = SearchRequest(start_page="Page A", end_page="Page C")
-        path_result = path_service.find_path(search_request)
-
-        assert path_result.path == ["Page A", "Page B", "Page C"]
-        assert path_result.length == 3
-
-    def test_service_error_propagation(self, mock_wikipedia_client, mock_cache_service):
-        """Test that service errors are properly propagated."""
-        # Mock Wikipedia client to raise exception
-        mock_wikipedia_client.page_exists.side_effect = Exception("Wikipedia API error")
-
-        service = ExploreService(mock_wikipedia_client, mock_cache_service)
-        request = ExploreRequest(start_page="Test Page")
-
-        with pytest.raises(Exception, match="Wikipedia API error"):
-            service.explore_page(request)
-
 
 class TestValidatePagesDisambiguation:
     """Tests for disambiguation handling in validate_pages."""
 
     def test_disambiguation_end_page_raises(
-        self, mock_wikipedia_client, mock_cache_service
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
     ):
         mock_wikipedia_client.get_page_with_redirect_info.side_effect = lambda page: {
             "exists": True,
@@ -400,9 +221,45 @@ class TestValidatePagesDisambiguation:
             "was_redirected": False,
             "is_disambiguation": page == "Mercury",
         }
-        service = PathFindingService(Mock(), mock_cache_service, mock_wikipedia_client)
+        service = PathFindingService(
+            mock_path_finder, mock_cache_service, mock_wikipedia_client
+        )
         with pytest.raises(DisambiguationPageError):
             service.validate_pages("A", "Mercury")
+
+    def test_disambiguation_start_page_is_allowed(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """Disambiguation start pages do not raise — the user navigates from them."""
+        mock_wikipedia_client.get_page_with_redirect_info.side_effect = lambda page: {
+            "exists": True,
+            "final_title": page,
+            "was_redirected": False,
+            "is_disambiguation": page == "Mercury",
+        }
+        service = PathFindingService(
+            mock_path_finder, mock_cache_service, mock_wikipedia_client
+        )
+        start_exists, end_exists, details = service.validate_pages("Mercury", "Target")
+        assert start_exists is True
+        assert end_exists is True
+        assert details["start_page"]["is_disambiguation"] is True
+
+    def test_validate_returns_redirect_info(
+        self, mock_wikipedia_client, mock_cache_service, mock_path_finder
+    ):
+        """Redirect metadata is surfaced in validation_details."""
+        mock_wikipedia_client.get_page_with_redirect_info.side_effect = lambda page: {
+            "exists": True,
+            "final_title": "AI" if page == "Artificial intelligence" else page,
+            "was_redirected": page == "Artificial intelligence",
+            "is_disambiguation": False,
+        }
+        service = PathFindingService(
+            mock_path_finder, mock_cache_service, mock_wikipedia_client
+        )
+        _, _, details = service.validate_pages("Artificial intelligence", "Python")
+        assert details["start_page"]["was_redirected"] is True
 
 
 class TestCacheManagementService:

--- a/tests/unit/test_cache_impl.py
+++ b/tests/unit/test_cache_impl.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import Mock
 
 import pytest
 import redis
@@ -42,7 +43,7 @@ def test_cache_set_success_does_not_raise(mock_redis):
     cache.set("x", {"y": 1})
 
 
-def test_cache_delete_exists_and_ttl(mock_redis):
+def test_cache_delete_exists(mock_redis):
     cache = RedisCache(mock_redis)
 
     cache.delete("k")
@@ -50,9 +51,6 @@ def test_cache_delete_exists_and_ttl(mock_redis):
 
     mock_redis.exists.return_value = 1
     assert cache.exists("k") is True
-
-    mock_redis.ttl.return_value = 42
-    assert cache.get_ttl("k") == 42
 
 
 def test_cache_delete_and_exists_error_raises(mock_redis):
@@ -87,28 +85,6 @@ def test_cache_clear_pattern_error(mock_redis):
         cache.clear_pattern("*")
 
 
-def test_cache_increment_and_error(mock_redis):
-    cache = RedisCache(mock_redis)
-    mock_redis.incrby.return_value = 5
-    assert cache.increment("c", 2) == 5
-
-    mock_redis.incrby.side_effect = redis.RedisError("boom")
-    with pytest.raises(CacheConnectionError):
-        cache.increment("c", 1)
-
-
-def test_cache_set_if_not_exists(mock_redis):
-    cache = RedisCache(mock_redis, default_ttl=9)
-    mock_redis.set.return_value = True
-    assert cache.set_if_not_exists("k", {"v": 1}) is True
-    mock_redis.set.assert_called()
-
-    mock_redis.set.return_value = False
-    assert cache.set_if_not_exists("k", {"v": 1}) is False
-
-    # Avoid triggering code path that references non-existent JSONEncodeError
-
-
 def test_cache_set_error_raises(mock_redis):
     cache = RedisCache(mock_redis)
     mock_redis.setex.side_effect = redis.RedisError("write failed")
@@ -116,36 +92,230 @@ def test_cache_set_error_raises(mock_redis):
         cache.set("k", {"v": 1})
 
 
-def test_cache_set_if_not_exists_error(mock_redis):
+def test_ping_success(mock_redis):
     cache = RedisCache(mock_redis)
-    mock_redis.set.side_effect = redis.RedisError("write failed")
+    mock_redis.ping.return_value = True
+    assert cache.ping() is True
+
+
+def test_ping_redis_error_returns_false(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.ping.side_effect = redis.RedisError("connection refused")
+    assert cache.ping() is False
+
+
+def test_delete_many_calls_pipeline(mock_redis):
+    cache = RedisCache(mock_redis)
+    deleted = []
+
+    class _Pipe:
+        def delete(self, key):
+            deleted.append(key)
+            return self
+
+        def execute(self):
+            return [1] * len(deleted)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    mock_redis.pipeline.side_effect = lambda: _Pipe()
+    cache.delete_many(["k1", "k2", "k3"])
+    assert set(deleted) == {"k1", "k2", "k3"}
+
+
+def test_delete_many_empty_is_noop(mock_redis):
+    cache = RedisCache(mock_redis)
+    cache.delete_many([])
+    mock_redis.pipeline.assert_not_called()
+
+
+def test_delete_many_redis_error_raises(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.pipeline.side_effect = redis.RedisError("err")
     with pytest.raises(CacheConnectionError):
-        cache.set_if_not_exists("k", {"v": 1})
+        cache.delete_many(["k1"])
 
 
-def test_get_links_from_cache_and_set_links(mock_redis):
+def test_set_add(mock_redis):
     cache = RedisCache(mock_redis)
-    import json
-
-    # set_links_in_cache
-    cache.set_links_in_cache("Python", ["A", "B"])
-    args, _ = mock_redis.setex.call_args
-    assert args[0] == "wiki_links:Python"
-
-    # get_links_from_cache hit
-    mock_redis.get.return_value = json.dumps(["A", "B"])
-    result = cache.get_links_from_cache("Python")
-    assert result == ["A", "B"]
-
-    # get_links_from_cache miss
-    mock_redis.get.return_value = None
-    assert cache.get_links_from_cache("Missing") is None
+    mock_redis.sadd = Mock(return_value=1)
+    cache.set_add("myset", "value")
+    mock_redis.sadd.assert_called_once_with("myset", "value")
 
 
-def test_get_ttl_error_returns_minus_one(mock_redis):
+def test_set_add_redis_error(mock_redis):
     cache = RedisCache(mock_redis)
-    mock_redis.ttl.side_effect = redis.RedisError("err")
-    assert cache.get_ttl("k") == -1
+    mock_redis.sadd = Mock(side_effect=redis.RedisError("sadd failed"))
+    with pytest.raises(CacheConnectionError):
+        cache.set_add("myset", "value")
+
+
+def test_set_contains_true_and_false(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.sismember = Mock(return_value=True)
+    assert cache.set_contains("myset", "value") is True
+    mock_redis.sismember.return_value = False
+    assert cache.set_contains("myset", "other") is False
+
+
+def test_set_contains_redis_error(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.sismember = Mock(side_effect=redis.RedisError("sismember failed"))
+    with pytest.raises(CacheConnectionError):
+        cache.set_contains("myset", "value")
+
+
+def test_set_add_many_calls_pipeline(mock_redis):
+    cache = RedisCache(mock_redis)
+    added = []
+
+    class _Pipe:
+        def sadd(self, key, val):
+            added.append((key, val))
+            return self
+
+        def execute(self):
+            return [1] * len(added)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    mock_redis.pipeline.side_effect = lambda: _Pipe()
+    cache.set_add_many("myset", ["a", "b", "c"])
+    assert len(added) == 3
+    assert all(key == "myset" for key, _ in added)
+    assert {val for _, val in added} == {"a", "b", "c"}
+
+
+def test_set_add_many_empty_is_noop(mock_redis):
+    cache = RedisCache(mock_redis)
+    cache.set_add_many("myset", [])
+    mock_redis.pipeline.assert_not_called()
+
+
+def test_set_add_many_redis_error(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.pipeline.side_effect = redis.RedisError("pipeline failed")
+    with pytest.raises(CacheConnectionError):
+        cache.set_add_many("myset", ["a"])
+
+
+def test_set_contains_many(mock_redis):
+    cache = RedisCache(mock_redis)
+
+    class _Pipe:
+        def sismember(self, key, val):
+            return self
+
+        def execute(self):
+            return [True, False, True]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    mock_redis.pipeline.side_effect = lambda: _Pipe()
+    result = cache.set_contains_many("myset", ["a", "b", "c"])
+    assert result == [True, False, True]
+
+
+def test_set_contains_many_empty(mock_redis):
+    cache = RedisCache(mock_redis)
+    assert cache.set_contains_many("myset", []) == []
+
+
+def test_set_contains_many_redis_error(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.pipeline.side_effect = redis.RedisError("pipeline failed")
+    with pytest.raises(CacheConnectionError):
+        cache.set_contains_many("myset", ["a", "b"])
+
+
+def test_hash_set(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.hset = Mock(return_value=1)
+    cache.hash_set("myhash", "field", "value")
+    mock_redis.hset.assert_called_once_with("myhash", "field", "value")
+
+
+def test_hash_set_redis_error(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.hset = Mock(side_effect=redis.RedisError("hset failed"))
+    with pytest.raises(CacheConnectionError):
+        cache.hash_set("myhash", "field", "value")
+
+
+def test_hash_get_str_value(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.hget = Mock(return_value="value")
+    assert cache.hash_get("myhash", "field") == "value"
+
+
+def test_hash_get_bytes_decoded(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.hget = Mock(return_value=b"value")
+    assert cache.hash_get("myhash", "field") == "value"
+
+
+def test_hash_get_missing_returns_none(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.hget = Mock(return_value=None)
+    assert cache.hash_get("myhash", "field") is None
+
+
+def test_hash_get_redis_error(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.hget = Mock(side_effect=redis.RedisError("hget failed"))
+    with pytest.raises(CacheConnectionError):
+        cache.hash_get("myhash", "field")
+
+
+def test_hash_set_many(mock_redis):
+    cache = RedisCache(mock_redis)
+    calls = []
+
+    class _Pipe:
+        def hset(self, key, field, val):
+            calls.append((key, field, val))
+            return self
+
+        def execute(self):
+            return [1] * len(calls)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    mock_redis.pipeline.side_effect = lambda: _Pipe()
+    cache.hash_set_many("myhash", {"f1": "v1", "f2": "v2"})
+    assert len(calls) == 2
+    assert all(key == "myhash" for key, _, _ in calls)
+    fields = {f for _, f, _ in calls}
+    assert fields == {"f1", "f2"}
+
+
+def test_hash_set_many_empty_is_noop(mock_redis):
+    cache = RedisCache(mock_redis)
+    cache.hash_set_many("myhash", {})
+    mock_redis.pipeline.assert_not_called()
+
+
+def test_hash_set_many_redis_error(mock_redis):
+    cache = RedisCache(mock_redis)
+    mock_redis.pipeline.side_effect = redis.RedisError("pipeline failed")
+    with pytest.raises(CacheConnectionError):
+        cache.hash_set_many("myhash", {"f": "v"})
 
 
 def test_get_redis_connection_error(monkeypatch):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -10,7 +10,6 @@ from app.utils.exceptions import (
     PathFindingError,
     PathNotFoundError,
     TaskError,
-    TaskTimeoutError,
     WikipediaAPIError,
     WikipediaError,
     WikipediaPageNotFoundError,
@@ -164,27 +163,6 @@ class TestTaskError:
     def test_with_explicit_message(self):
         exc = TaskError("boom")
         assert exc.message == "boom"
-
-
-class TestTaskTimeoutError:
-    def test_default(self):
-        exc = TaskTimeoutError()
-        assert "timed out" in exc.message
-        assert exc.code == "TASK_TIMEOUT"
-        assert exc.timeout is None
-
-    def test_with_task_id(self):
-        exc = TaskTimeoutError(task_id="t1")
-        assert "t1" in exc.message
-
-    def test_with_timeout(self):
-        exc = TaskTimeoutError(timeout=300)
-        assert "300" in exc.message
-
-    def test_with_both(self):
-        exc = TaskTimeoutError(task_id="t1", timeout=60)
-        assert "t1" in exc.message
-        assert "60" in exc.message
 
 
 class TestConfigurationError:

--- a/tests/unit/test_external_wikipedia_client.py
+++ b/tests/unit/test_external_wikipedia_client.py
@@ -10,7 +10,8 @@ from app.external.wikipedia import WikipediaClient
 class DummyResponse:
     def __init__(self, payload, status=200, raise_exc=None):
         self._payload = payload
-        self._status = status
+        self.status_code = status
+        self.headers: dict = {}
         self._raise = raise_exc
 
     def raise_for_status(self):
@@ -26,12 +27,16 @@ class DummySession:
         self.headers = {}
         self.calls = []
         self._response = DummyResponse({"query": {}})
+        self._raise_exc = None
 
     def set_response(self, payload, raise_exc=None):
-        self._response = DummyResponse(payload, raise_exc=raise_exc)
+        self._raise_exc = raise_exc
+        self._response = DummyResponse(payload)
 
     def get(self, url, params=None, timeout=None):
         self.calls.append((url, params, timeout))
+        if self._raise_exc:
+            raise self._raise_exc
         return self._response
 
 
@@ -131,7 +136,11 @@ def test_get_links_bulk_empty_returns_empty():
 def test_fetch_single_page_success_and_error():
     """_fetch_single_page fetches links and raises WikipediaAPIError on network failure."""
     session = DummySession()
-    client = WikipediaClient(session=cast(requests.Session, session))
+    # max_retries=1 and request_delay=0.0 keep the test instant: no backoff sleep,
+    # no rate-limiter sleep.
+    client = WikipediaClient(
+        session=cast(requests.Session, session), max_retries=1, request_delay=0.0
+    )
 
     # Successful fetch — page with two article links
     session.set_response(

--- a/tests/unit/test_factory_and_tasks_config.py
+++ b/tests/unit/test_factory_and_tasks_config.py
@@ -24,11 +24,11 @@ def test_service_factory_lifecycle(monkeypatch):
         assert r1 is fake_redis
 
         cache = ServiceFactory.get_cache_service()
-        assert cache.redis_client is fake_redis
+        assert cache._redis_client is fake_redis
         assert cache.default_ttl == app.config.get("CACHE_TTL")
 
         queue = ServiceFactory.get_queue_service()
-        assert queue.redis_client is fake_redis
+        assert queue._redis_client is fake_redis
 
         wiki = ServiceFactory.get_wikipedia_client()
         # wikipedia client should have cache and configured workers
@@ -38,8 +38,6 @@ def test_service_factory_lifecycle(monkeypatch):
         # create services
         pf = ServiceFactory.create_pathfinding_service("bfs")
         assert pf is not None
-        ex = ServiceFactory.create_explore_service()
-        assert ex is not None
         ws = ServiceFactory.create_wikipedia_service()
         assert ws is not None
         cms = ServiceFactory.create_cache_management_service()
@@ -60,12 +58,8 @@ def test_configure_task_routes_and_periodic_tasks():
     configure_task_routes(app)
     assert isinstance(app.conf.task_routes, dict)
     assert "app.infrastructure.tasks.find_path_task" in app.conf.task_routes
-    assert app.conf.task_time_limit == 600
-    assert app.conf.task_soft_time_limit == 300
     assert app.conf.result_expires == 3600
     assert app.conf.result_persistent is True
-    assert app.conf.task_acks_late is True
-    assert app.conf.worker_prefetch_multiplier == 1
     assert app.conf.task_reject_on_worker_lost is True
 
     configure_periodic_tasks(app)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,11 +1,8 @@
 from app.core.models import (
     CacheStats,
-    ExploreRequest,
-    ExploreResult,
     HealthStatus,
     PathResult,
     SearchRequest,
-    TaskInfo,
     TaskStatus,
     WikipediaPage,
 )
@@ -78,58 +75,6 @@ class TestPathResult:
         assert result.is_valid is False
 
 
-class TestExploreResult:
-    """Unit tests for ExploreResult model."""
-
-    def test_valid_explore_result(self):
-        """Test creating a valid ExploreResult."""
-        result = ExploreResult(
-            start_page="Test Page",
-            nodes=["Test Page", "Link 1", "Link 2"],
-            edges=[("Test Page", "Link 1"), ("Test Page", "Link 2")],
-            total_links=2,
-        )
-
-        assert result.start_page == "Test Page"
-        assert result.nodes == ["Test Page", "Link 1", "Link 2"]
-        assert result.edges == [("Test Page", "Link 1"), ("Test Page", "Link 2")]
-        assert result.total_links == 2
-        assert result.is_valid is True
-
-    def test_invalid_explore_result_start_not_in_nodes(self):
-        """Test ExploreResult where start page is not in nodes."""
-        result = ExploreResult(
-            start_page="Test Page",
-            nodes=["Link 1", "Link 2"],  # Start page not included
-            edges=[("Test Page", "Link 1"), ("Test Page", "Link 2")],
-            total_links=2,
-        )
-
-        assert result.is_valid is False
-
-    def test_invalid_explore_result_empty_nodes(self):
-        """Test ExploreResult with empty nodes."""
-        result = ExploreResult(
-            start_page="Test Page",
-            nodes=[],
-            edges=[],
-            total_links=0,  # Empty nodes
-        )
-
-        assert result.is_valid is False
-
-    def test_invalid_explore_result_negative_total_links(self):
-        """Test ExploreResult with negative total links."""
-        result = ExploreResult(
-            start_page="Test Page",
-            nodes=["Test Page"],
-            edges=[],
-            total_links=-1,  # Negative total links
-        )
-
-        assert result.is_valid is False
-
-
 class TestSearchRequest:
     """Unit tests for SearchRequest model."""
 
@@ -180,38 +125,6 @@ class TestSearchRequest:
         assert request.validate() is False
 
 
-class TestExploreRequest:
-    """Unit tests for ExploreRequest model."""
-
-    def test_valid_explore_request(self):
-        """Test creating a valid ExploreRequest."""
-        request = ExploreRequest(start_page="Test Page", max_links=15)
-
-        assert request.start_page == "Test Page"
-        assert request.max_links == 15
-        assert request.validate() is True
-
-    def test_explore_request_minimal(self):
-        """Test ExploreRequest with minimal required fields."""
-        request = ExploreRequest(start_page="Test Page")
-
-        assert request.start_page == "Test Page"
-        assert request.max_links is None
-        assert request.validate() is True
-
-    def test_invalid_explore_request_empty_start(self):
-        """Test ExploreRequest with empty start page."""
-        request = ExploreRequest(start_page="")
-
-        assert request.validate() is False
-
-    def test_invalid_explore_request_whitespace_only(self):
-        """Test ExploreRequest with whitespace-only start page."""
-        request = ExploreRequest(start_page="   ")
-
-        assert request.validate() is False
-
-
 class TestWikipediaPage:
     """Unit tests for WikipediaPage model."""
 
@@ -251,37 +164,6 @@ class TestWikipediaPage:
         page = WikipediaPage(title="   ")
 
         assert page.is_valid is False
-
-
-class TestTaskInfo:
-    """Unit tests for TaskInfo model."""
-
-    def test_task_info_creation(self):
-        """Test creating a TaskInfo."""
-        task_info = TaskInfo(
-            task_id="test-task-123",
-            status=TaskStatus.IN_PROGRESS,
-            result={"path": ["A", "B"]},
-            error=None,
-            progress={"current": 50, "total": 100},
-            created_at="2025-01-01T00:00:00Z",
-            updated_at="2025-01-01T00:01:00Z",
-        )
-
-        assert task_info.task_id == "test-task-123"
-        assert task_info.status == TaskStatus.IN_PROGRESS
-        assert task_info.result == {"path": ["A", "B"]}
-        assert task_info.error is None
-        assert task_info.progress == {"current": 50, "total": 100}
-
-    def test_task_info_minimal(self):
-        """Test TaskInfo with minimal required fields."""
-        task_info = TaskInfo(task_id="test-task-123", status=TaskStatus.PENDING)
-
-        assert task_info.task_id == "test-task-123"
-        assert task_info.status == TaskStatus.PENDING
-        assert task_info.result is None
-        assert task_info.error is None
 
 
 class TestTaskStatus:

--- a/tests/unit/test_redis_queue_impl.py
+++ b/tests/unit/test_redis_queue_impl.py
@@ -30,20 +30,9 @@ def test_queue_push_pop_length_clear(mock_redis):
     mock_redis.delete.assert_called()
 
 
-def test_queue_peek_and_errors(mock_redis):
+def test_queue_errors(mock_redis):
     q = RedisQueue(mock_redis)
 
-    # peek None
-    mock_redis.lindex.return_value = None
-    assert q.peek("q", 0) is None
-
-    # peek value
-    mock_redis.lindex.return_value = json.dumps([1, 2, 3])
-    assert q.peek("q", 1) == [1, 2, 3]
-
-    # Avoid triggering code path that references non-existent JSONEncodeError
-
-    mock_redis.lpush.side_effect = None
     mock_redis.lpop.side_effect = redis.RedisError("bad pop")
     with pytest.raises(CacheConnectionError):
         q.pop("q")
@@ -64,16 +53,6 @@ def test_queue_push_error_raises(mock_redis):
     mock_redis.rpush.side_effect = redis.RedisError("push failed")
     with pytest.raises(CacheConnectionError):
         q.push("q", {"x": 1})
-
-
-def test_queue_push_front(mock_redis):
-    q = RedisQueue(mock_redis)
-    q.push_front("q", {"a": 1})
-    mock_redis.lpush.assert_called_once()
-
-    mock_redis.lpush.side_effect = redis.RedisError("front fail")
-    with pytest.raises(CacheConnectionError):
-        q.push_front("q", {"a": 1})
 
 
 def test_queue_pop_batch_zero_count(mock_redis):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -168,18 +168,50 @@ class TestFindPathTask:
 
     def test_retryable_error_max_retries_exceeded(self, app):
         with app.app_context():
+            from app.infrastructure.tasks import find_path_task
             from app.utils.exceptions import WikipediaAPIError
 
-            # When retries == max_retries, no retry is attempted — returns FAILURE
-            result = _apply(
-                svc=_build_service(find_path_raises=WikipediaAPIError("timeout"))
-            )
-            # With task_eager_propagates=False and retries exhausted or re-raised,
-            # we get either FAILURE or the retry behaviour; either way status != SUCCESS
-            assert result is not None
+            svc = _build_service(find_path_raises=WikipediaAPIError("timeout"))
+            with patch(
+                "app.infrastructure.tasks.get_pathfinding_service", return_value=svc
+            ):
+                # Eager retries run synchronously; after max_retries the task
+                # returns the MAX_RETRIES_EXCEEDED failure dict.
+                result = find_path_task.apply(args=["A", "B", "bfs"], retries=3).result  # type: ignore[attr-defined]
+            assert result["status"] == "FAILURE"
+            assert result["code"] == "MAX_RETRIES_EXCEEDED"
+
+    def test_progress_callback_is_passed_to_service(self, app):
+        with app.app_context():
+            svc = _build_service(path=["A", "B"])
+            with patch(
+                "app.infrastructure.tasks.get_pathfinding_service", return_value=svc
+            ) as mock_get:
+                from app.infrastructure.tasks import find_path_task
+
+                find_path_task.apply(args=["A", "B", "bfs"])  # type: ignore[attr-defined]
+
+            _algo, callback = mock_get.call_args[0]
+            assert callable(callback)
 
 
 class TestHealthCheckTask:
+    def test_ping_failure_returns_failure(self, app):
+        with app.app_context():
+            mock_cache = Mock()
+            mock_cache.ping.return_value = False  # Redis unreachable
+
+            with patch(
+                "app.core.factory.ServiceFactory.get_cache_service",
+                return_value=mock_cache,
+            ):
+                from app.infrastructure.tasks import health_check_task
+
+                result = health_check_task.apply().result  # type: ignore[attr-defined]
+
+            assert result["status"] == "FAILURE"
+            assert "Redis ping failed" in result["error"]
+
     def test_success(self, app):
         with app.app_context():
             mock_redis = Mock()
@@ -256,6 +288,21 @@ class TestCacheCleanupTask:
             assert result["status"] == "SUCCESS"
             assert result["cleared_count"] == 7
             assert result["pattern"] == "bfs_*"
+
+    def test_default_pattern(self, app):
+        with app.app_context():
+            mock_mgmt = Mock()
+            mock_mgmt.clear_cache_pattern.return_value = 0
+
+            with patch(
+                "app.core.factory.get_cache_management_service", return_value=mock_mgmt
+            ):
+                from app.infrastructure.tasks import cache_cleanup_task
+
+                result = cache_cleanup_task.apply().result  # type: ignore[attr-defined]
+
+            assert result["pattern"] == "bfs_*"
+            mock_mgmt.clear_cache_pattern.assert_called_once_with("bfs_*")
 
     def test_failure(self, app):
         with app.app_context():


### PR DESCRIPTION
…l, and architecture docs

Task management endpoints:
- GET /tasks — list active/reserved/scheduled Celery tasks via inspect()
- DELETE /tasks/<id> — revoke a specific task (SIGTERM if running)
- DELETE /tasks — revoke all active + reserved tasks All three are documented in Swagger via Flasgger YAML docstrings.

Pathfinding:
- Add BidirectionalBFSPathFinder (new default algorithm) — searches from both start and end simultaneously using Wikipedia backlinks for the reverse frontier
- Add BidirProgressAggregator for thread-safe dual-frontier progress reporting
- RedisBasedBFSPathFinder retained as the explicit 'bfs' algorithm option

Wikipedia client:
- _bulk_fetch shared scaffolding for links + backlinks with ThreadPoolExecutor
- _acquire_rate_slot shared threading.Lock rate limiter across fetch threads
- _request_with_backoff: exponential backoff on 429/5xx, respects Retry-After
- Pagination via plcontinue up to WIKIPEDIA_MAX_PAGINATE_CALLS (default 3, 1500 links/page)

Cache layer (RedisCache):
- Full set/hash/pipeline interface: set_add, set_contains, set_add_many, set_contains_many, hash_set, hash_get, hash_set_many, delete_many, ping

Test suite:
- 188 tests, 89% coverage — no real Redis or Wikipedia calls
- Stateful mock fixtures (in-memory dicts) in conftest for cache and queue
- Celery eager execution with cache+memory:// backend for task tests
- New test classes: TestBidirProgressAggregator, TestBidirectionalBFSPathFinder, TestProgressCallback, TestCacheManagementService, TestValidatePagesDisambiguation

Architecture docs:
- docs/architecture_guide.tex fully updated: bidirectional BFS decision, BidirProgressAggregator, task management endpoints, Redis key table, Wikipedia client internals, Testing Architecture section (Section 9)