### PR TITLE
fix: frontend bugs - XSS, race conditions, dead code cleanup

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
         <header>
             <div class="header-logo-container">
                 <img src="/static/logo.svg" alt="Iris Logo" class="header-logo">
-                <h1 style="margin: 0;">Iris: Wikipedia Path Finder</h1>
+                <h1>Iris: Wikipedia Path Finder</h1>
             </div>
             <p>Discover a path between any two Wikipedia pages through connected links</p>
             <div class="header-actions">

--- a/static/script.js
+++ b/static/script.js
@@ -1,7 +1,8 @@
 // Use current domain for API calls (works for both localhost and deployed domains)
 const API_BASE = window.location.origin;
 let currentTaskId = null;
-let pollingInterval = null;
+let pollTimeoutId = null;
+let abortController = null;
 let graph = null;
 
 // State management
@@ -145,15 +146,21 @@ class PathFinderUI {
     }
 
     clearActiveTask() {
-        // Stop any ongoing polling
-        if (pollingInterval) {
-            clearInterval(pollingInterval);
-            pollingInterval = null;
+        // Cancel pending poll timeout
+        if (pollTimeoutId) {
+            clearTimeout(pollTimeoutId);
+            pollTimeoutId = null;
         }
-        
+
+        // Abort any in-flight fetch requests
+        if (abortController) {
+            abortController.abort();
+            abortController = null;
+        }
+
         // Clear current task ID
         currentTaskId = null;
-        
+
         // Update button state
         this.updateButtonState();
     }
@@ -313,9 +320,12 @@ class PathFinderUI {
             this.showLoading();
             this.hidePathDisplay();
             this.showVisualizationSection();
-            
+
             // Update search path header immediately with actual pages
             document.getElementById('searchPath').textContent = `${startPage} → ${endPage}`;
+
+            // Create a new AbortController for this request chain
+            abortController = new AbortController();
 
             const response = await fetch(`${API_BASE}/getPath`, {
                 method: 'POST',
@@ -326,12 +336,17 @@ class PathFinderUI {
                     start: startPage,
                     end: endPage,
                     algorithm: "bidirectional"
-                })
+                }),
+                signal: abortController.signal
             });
 
             if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.message || `HTTP ${response.status}`);
+                let message = `HTTP ${response.status}`;
+                try {
+                    const errorData = await response.json();
+                    message = errorData.message || message;
+                } catch { /* non-JSON response */ }
+                throw new Error(message);
             }
 
             const data = await response.json();
@@ -343,6 +358,7 @@ class PathFinderUI {
             this.pollTaskStatus();
 
         } catch (error) {
+            if (error.name === 'AbortError') return;
             const section = document.getElementById('visualizationSection');
             section.classList.remove('show');
             this.showError(`Failed to start pathfinding: ${error.message}`);
@@ -353,7 +369,9 @@ class PathFinderUI {
         if (!currentTaskId) return;
 
         try {
-            const response = await fetch(`${API_BASE}/tasks/status/${currentTaskId}`);
+            const response = await fetch(`${API_BASE}/tasks/status/${currentTaskId}`, {
+                signal: abortController?.signal
+            });
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
@@ -368,7 +386,7 @@ class PathFinderUI {
                     // Show zeroed stats while we wait
                     this.resetProgressUI();
                     // Header already shows start→end; stats will populate on first update
-                    setTimeout(() => this.pollTaskStatus(), 1000);
+                    pollTimeoutId = setTimeout(() => this.pollTaskStatus(), 1000);
                     break;
 
                 case 'IN_PROGRESS':
@@ -377,7 +395,7 @@ class PathFinderUI {
                     if (data.progress) {
                         this.updateProgressDisplay(data.progress);
                     }
-                    setTimeout(() => this.pollTaskStatus(), 1000);
+                    pollTimeoutId = setTimeout(() => this.pollTaskStatus(), 1000);
                     break;
 
                 case 'SUCCESS':
@@ -410,6 +428,7 @@ class PathFinderUI {
             }
 
         } catch (error) {
+            if (error.name === 'AbortError') return;
             this.clearActiveTask();
             this.hideLoading();
             const section = document.getElementById('visualizationSection');
@@ -559,7 +578,7 @@ class PathFinderUI {
                 if (isTouch) return;
                 this.tooltip
                     .style('opacity', 1)
-                    .html(`${d.name}<br/>Step ${d.index + 1}`)
+                    .text(`${d.name} — Step ${d.index + 1}`)
                     .style('left', (event.pageX + 10) + 'px')
                     .style('top', (event.pageY - 10) + 'px');
             })

--- a/static/styles.css
+++ b/static/styles.css
@@ -415,14 +415,8 @@ header p {
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 16px;
-}
-
-.graph-loader-animation {
-    margin-bottom: 16px;
-    display: flex;
-    justify-content: center;
     gap: 4px;
+    margin-bottom: 16px;
 }
 
 .graph-loader-dot {
@@ -669,64 +663,6 @@ header p {
 }
 
 
-/* Progress Container */
-.progress-container {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    align-items: center;
-}
-
-.progress-bar {
-    width: 280px;
-    height: 6px;
-    background: var(--bg-tertiary);
-    border-radius: 3px;
-    overflow: hidden;
-    border: 1px solid var(--border-secondary);
-}
-
-.progress-bar-fill {
-    height: 100%;
-    background: linear-gradient(90deg, var(--accent-blue), var(--accent-blue-hover));
-    width: 0%;
-    transition: width 0.3s ease;
-    border-radius: 3px;
-    position: relative;
-    overflow: hidden;
-}
-
-.progress-bar-fill::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-    animation: shimmer 2.5s infinite;
-}
-
-@keyframes shimmer {
-    0% {
-        left: -100%;
-    }
-
-    100% {
-        left: 100%;
-    }
-}
-
-.progress-text {
-    font-size: 14px;
-    color: var(--text-secondary);
-    font-weight: 500;
-    max-width: 300px;
-    word-wrap: break-word;
-    text-align: center;
-}
-
 /* Path Steps */
 .path-steps-container {
     background: var(--bg-secondary);
@@ -961,4 +897,3 @@ header p {
         min-height: 400px;
     }
 }
-/* no-op: removed pulse graph */


### PR DESCRIPTION
- Fix polling race condition: replace unused pollingInterval with
  pollTimeoutId that actually cancels pending setTimeout callbacks
- Fix XSS: use .text() instead of .html() for tooltip content
- Fix error parsing: wrap response.json() in try/catch for non-JSON errors
- Add AbortController to all fetch calls for proper request cancellation
- Ignore AbortError in catch blocks to prevent false error messages
- Remove duplicate .graph-loader-animation CSS rule block
- Remove 57 lines of dead CSS (.progress-container, .progress-bar, etc.)
- Remove redundant inline style on h1 (already handled by CSS reset)
- Remove dead trailing comment

https://claude.ai/code/session_01BYVHYwpRz4dBPpQpvxFW8g